### PR TITLE
Remove data_hash from metadata and make metadata a Vec<u8>

### DIFF
--- a/src/arguments.rs
+++ b/src/arguments.rs
@@ -13,5 +13,3 @@ impl Arguments {
     self.subcommand.run(self.options)
   }
 }
-
-

--- a/src/arguments.rs
+++ b/src/arguments.rs
@@ -13,3 +13,5 @@ impl Arguments {
     self.subcommand.run(self.options)
   }
 }
+
+

--- a/src/subcommand/verify.rs
+++ b/src/subcommand/verify.rs
@@ -15,7 +15,7 @@ impl Verify {
       .with_context(|| format!("Failed to verify NFT at `{}`", self.input_path.display()))?;
 
     eprintln!("NFT is valid!");
-    eprintln!("Ordinal: {}", nft.ordinal());
+    eprintln!("Ordinal: {}", nft.ordinal()?);
     eprintln!("Issuer: {}", nft.issuer());
     eprintln!("Data hash: {}", nft.data_hash());
 


### PR DESCRIPTION
1. Nft has that information (implicitly, since it can be derived from nft.data).
2. vec u8 ensures hash stability