### PR TITLE
Change slot notation to AxBxCxD

### DIFF
--- a/bip.mediawiki
+++ b/bip.mediawiki
@@ -93,7 +93,7 @@ A satpoint may be used to indicate the location of an ordinal within an output. 
 
 `680df1e4d43016571e504b0b142ee43c5c0b83398a97bdcfd94ea6f287322d22:0:6`
 
-A slot may be used to indicate the output of an ordinal without referring to a transaction ID, by substituting the block height and transaction index within the block for the transaction ID. It is written as a x'ed quad. For example, the ordinal at offset 100 in the output at offset 1, in the coinbase transaction of block 83 can be written as:
+A slot may be used to indicate the output of an ordinal without referring to a transaction ID, by substituting the block height and transaction index within the block for the transaction ID. It is written as a x'ed quad, similar to a Lightning Network short channel ID, but with an additional number indicating the offset of the ordinal within the output. For example, the ordinal at offset 100 in the output at offset 1, in the coinbase transaction of block 83 can be written as:
 
 `83x0x1x100`
 

--- a/bip.mediawiki
+++ b/bip.mediawiki
@@ -93,7 +93,7 @@ A satpoint may be used to indicate the location of an ordinal within an output. 
 
 `680df1e4d43016571e504b0b142ee43c5c0b83398a97bdcfd94ea6f287322d22:0:6`
 
-A slot may be used to indicate the output of an ordinal without referring to a transaction ID, by substituting the block height and transaction index within the block for the transaction ID. It is written as a x'ed quad, similar to a Lightning Network short channel ID, but with an additional number indicating the offset of the ordinal within the output. For example, the ordinal at offset 100 in the output at offset 1, in the coinbase transaction of block 83 can be written as:
+A slot may be used to indicate the output of an ordinal without referring to a transaction ID, by substituting the block height and transaction index within the block for the transaction ID. It is written as a x'ed quad, similar to a Lightning Network short channel ID with an additional number indicating the offset of the ordinal within the output. For example, the ordinal at offset 100 in the output at offset 1, in the coinbase transaction of block 83 can be written as:
 
 `83x0x1x100`
 

--- a/bip.mediawiki
+++ b/bip.mediawiki
@@ -93,9 +93,9 @@ A satpoint may be used to indicate the location of an ordinal within an output. 
 
 `680df1e4d43016571e504b0b142ee43c5c0b83398a97bdcfd94ea6f287322d22:0:6`
 
-A slot may be used to indicate the output of an ordinal without referring to a transaction ID, by substituting the block height and transaction index within the block for the transaction ID. It is written as a dotted quad. For example, the ordinal at offset 100 in the output at offset 1, in the coinbase transaction of block 83 can be written as:
+A slot may be used to indicate the output of an ordinal without referring to a transaction ID, by substituting the block height and transaction index within the block for the transaction ID. It is written as a x'ed quad. For example, the ordinal at offset 100 in the output at offset 1, in the coinbase transaction of block 83 can be written as:
 
-`83.0.1.100`
+`83x0x1x100`
 
 Satoshis with ordinals that are not valuable or notable can be referred to as cardinal, as their identity does not matter, only the amount. A cardinal output is one whose ordinals are unimportant for the purpose at hand, for example an output used only to provide padding to avoid creating a transaction with an output below the dust limit.
 

--- a/bip.mediawiki
+++ b/bip.mediawiki
@@ -93,7 +93,7 @@ A satpoint may be used to indicate the location of an ordinal within an output. 
 
 `680df1e4d43016571e504b0b142ee43c5c0b83398a97bdcfd94ea6f287322d22:0:6`
 
-A slot may be used to indicate the output of an ordinal without referring to a transaction ID, by substituting the block height and transaction index within the block for the transaction ID. It is written as a x'ed quad, similar to a Lightning Network short channel ID with an additional number indicating the offset of the ordinal within the output. For example, the ordinal at offset 100 in the output at offset 1, in the coinbase transaction of block 83 can be written as:
+A slot may be used to indicate the output of an ordinal without referring to a transaction ID, by substituting the block height and transaction index within the block for the transaction ID. It is written as an x'ed quad, similar to a Lightning Network short channel ID with an additional number indicating the offset of the ordinal within the output. For example, the ordinal at offset 100 in the output at offset 1, in the coinbase transaction of block 83 can be written as:
 
 `83x0x1x100`
 

--- a/tests/find.rs
+++ b/tests/find.rs
@@ -14,7 +14,7 @@ fn first_satoshi() -> Result {
 fn first_satoshi_slot() -> Result {
   Test::new()?
     .command("find 0 --slot")
-    .expected_stdout("0.0.0.0\n")
+    .expected_stdout("0x0x0x0\n")
     .block()
     .run()
 }
@@ -33,7 +33,7 @@ fn second_satoshi() -> Result {
 fn second_satoshi_slot() -> Result {
   Test::new()?
     .command("find 1 --slot")
-    .expected_stdout("0.0.0.1\n")
+    .expected_stdout("0x0x0x1\n")
     .block()
     .run()
 }
@@ -53,7 +53,7 @@ fn first_satoshi_of_second_block() -> Result {
 fn first_satoshi_of_second_block_slot() -> Result {
   Test::new()?
     .command("find 5000000000 --slot")
-    .expected_stdout("1.0.0.0\n")
+    .expected_stdout("1x0x0x0\n")
     .block()
     .block()
     .run()
@@ -79,7 +79,7 @@ fn first_satoshi_spent_in_second_block() -> Result {
 fn first_satoshi_spent_in_second_block_slot() -> Result {
   Test::new()?
     .command("find 0 --slot")
-    .expected_stdout("1.1.0.0\n")
+    .expected_stdout("1x1x0x0\n")
     .block()
     .block()
     .transaction(TransactionOptions {
@@ -100,7 +100,7 @@ fn regression_empty_block_crash() -> Result {
       include_coinbase_transaction: false,
       ..Default::default()
     })
-    .expected_stdout("0.0.0.0\n")
+    .expected_stdout("0x0x0x0\n")
     .run()
 }
 
@@ -121,7 +121,7 @@ fn mining_and_spending_transaction_in_same_block() -> Result {
       output_count: 1,
       fee: 0,
     })
-    .expected_stdout("1.2.0.0\n")
+    .expected_stdout("1x2x0x0\n")
     .run()
 }
 


### PR DESCRIPTION
Change slot notation to `AxBxCxD` where:

A = Block height
B = Index of transaction in block
C = vout
D = Offset of ordinal in output