### PR TITLE
Move /list endpoint to /api/list

### DIFF
--- a/src/subcommand/server.rs
+++ b/src/subcommand/server.rs
@@ -65,7 +65,7 @@ impl Server {
         .route("/", get(Self::root))
         .route("/block/:hash", get(Self::block))
         .route("/ordinal/:ordinal", get(Self::ordinal))
-        .route("/api/list/:outpoint", get(Self::list))
+        .route("/api/list/:outpoint", get(Self::api_list))
         .route("/status", get(Self::status))
         .layer(extract::Extension(index))
         .layer(
@@ -206,7 +206,7 @@ impl Server {
     }
   }
 
-  async fn list(
+  async fn api_list(
     extract::Path(outpoint): extract::Path<OutPoint>,
     index: extract::Extension<Arc<Index>>,
   ) -> impl IntoResponse {

--- a/src/subcommand/server.rs
+++ b/src/subcommand/server.rs
@@ -65,7 +65,7 @@ impl Server {
         .route("/", get(Self::root))
         .route("/block/:hash", get(Self::block))
         .route("/ordinal/:ordinal", get(Self::ordinal))
-        .route("/list/:outpoint", get(Self::list))
+        .route("/api/list/:outpoint", get(Self::list))
         .route("/status", get(Self::status))
         .layer(extract::Extension(index))
         .layer(

--- a/tests/server.rs
+++ b/tests/server.rs
@@ -12,7 +12,7 @@ fn list() -> Result {
     .command(&format!("server --address 127.0.0.1 --http-port {port}"))
     .block()
     .request(
-      "list/0396bc915f141f7de025f72ae9b6bb8dcdb5f444fc245d8fac486ba67a38eef9:0",
+      "api/list/0396bc915f141f7de025f72ae9b6bb8dcdb5f444fc245d8fac486ba67a38eef9:0",
       200,
       "[[0,5000000000]]",
     )
@@ -36,13 +36,13 @@ fn continuously_index_ranges() -> Result {
   Test::new()?
     .command(&format!("server --address 127.0.0.1 --http-port {port}"))
     .request(
-      "list/0396bc915f141f7de025f72ae9b6bb8dcdb5f444fc245d8fac486ba67a38eef9:0",
+      "api/list/0396bc915f141f7de025f72ae9b6bb8dcdb5f444fc245d8fac486ba67a38eef9:0",
       404,
       "null",
     )
     .block()
     .request(
-      "list/0396bc915f141f7de025f72ae9b6bb8dcdb5f444fc245d8fac486ba67a38eef9:0",
+      "api/list/0396bc915f141f7de025f72ae9b6bb8dcdb5f444fc245d8fac486ba67a38eef9:0",
       200,
       "[[0,5000000000]]",
     )


### PR DESCRIPTION
From now on, endpoints returning raw JSON should be under /api/