### PR TITLE
Don't warn about installing bitcoind in deploy/setup

### DIFF
--- a/deploy/setup
+++ b/deploy/setup
@@ -1,7 +1,5 @@
 #!/usr/bin/env bash
 
-# N.B. Bitcoind must be installed as /usr/local/bin/bitcoind.
-
 set -euxo pipefail
 
 apt-get update --yes


### PR DESCRIPTION
The script installs bitcoind, so this note isn't necessary.