### PR TITLE
Improve names for a couple of properties

### DIFF
--- a/src/ordinal.rs
+++ b/src/ordinal.rs
@@ -446,6 +446,7 @@ mod tests {
     assert!(parse("0°2015′2015″0‴").is_ok());
     assert!(parse("0°2016′0″0‴").is_ok());
     assert!(parse("0°2016′1″0‴").is_err());
+    assert!(parse("0°0′336″0‴").is_ok());
   }
 
   #[test]

--- a/src/subcommand/server/templates/ordinal.rs
+++ b/src/subcommand/server/templates/ordinal.rs
@@ -30,13 +30,13 @@ mod tests {
           <dt>decimal</dt><dd>0.0</dd>
           <dt>degree</dt><dd>0°0′0″0‴</dd>
           <dt>name</dt><dd>nvtdijuwxlp</dd>
-          <dt>height</dt><dd>0</dd>
+          <dt>block</dt><dd>0</dd>
           <dt>cycle</dt><dd>0</dd>
           <dt>epoch</dt><dd>0</dd>
           <dt>period</dt><dd>0</dd>
           <dt>offset</dt><dd>0</dd>
           <dt>rarity</dt><dd><span class=mythic>mythic</span></dd>
-          <dt>block time</dt><dd>1970-01-01 00:00:00</dd>
+          <dt>time</dt><dd>1970-01-01 00:00:00</dd>
         </dl>
         <a>prev</a>
         <a href=/ordinal/1>next</a>
@@ -59,13 +59,13 @@ mod tests {
           <dt>decimal</dt><dd>6929999.0</dd>
           <dt>degree</dt><dd>5°209999′1007″0‴</dd>
           <dt>name</dt><dd>a</dd>
-          <dt>height</dt><dd>6929999</dd>
+          <dt>block</dt><dd>6929999</dd>
           <dt>cycle</dt><dd>5</dd>
           <dt>epoch</dt><dd>32</dd>
           <dt>period</dt><dd>3437</dd>
           <dt>offset</dt><dd>0</dd>
           <dt>rarity</dt><dd><span class=uncommon>uncommon</span></dd>
-          <dt>block time</dt><dd>1970-01-01 00:00:00</dd>
+          <dt>time</dt><dd>1970-01-01 00:00:00</dd>
         </dl>
         <a href=/ordinal/2099999997689998>prev</a>
         <a>next</a>
@@ -88,13 +88,13 @@ mod tests {
           <dt>decimal</dt><dd>0.1</dd>
           <dt>degree</dt><dd>0°0′0″1‴</dd>
           <dt>name</dt><dd>nvtdijuwxlo</dd>
-          <dt>height</dt><dd>0</dd>
+          <dt>block</dt><dd>0</dd>
           <dt>cycle</dt><dd>0</dd>
           <dt>epoch</dt><dd>0</dd>
           <dt>period</dt><dd>0</dd>
           <dt>offset</dt><dd>1</dd>
           <dt>rarity</dt><dd><span class=common>common</span></dd>
-          <dt>block time</dt><dd>1970-01-01 00:00:00</dd>
+          <dt>time</dt><dd>1970-01-01 00:00:00</dd>
         </dl>
         <a href=/ordinal/0>prev</a>
         <a href=/ordinal/2>next</a>

--- a/templates/ordinal.html
+++ b/templates/ordinal.html
@@ -3,13 +3,13 @@
   <dt>decimal</dt><dd>{{ self.ordinal.decimal() }}</dd>
   <dt>degree</dt><dd>{{ self.ordinal.degree() }}</dd>
   <dt>name</dt><dd>{{ self.ordinal.name() }}</dd>
-  <dt>height</dt><dd>{{ self.ordinal.height() }}</dd>
+  <dt>block</dt><dd>{{ self.ordinal.height() }}</dd>
   <dt>cycle</dt><dd>{{ self.ordinal.cycle() }}</dd>
   <dt>epoch</dt><dd>{{ self.ordinal.epoch() }}</dd>
   <dt>period</dt><dd>{{ self.ordinal.period() }}</dd>
   <dt>offset</dt><dd>{{ self.ordinal.third() }}</dd>
   <dt>rarity</dt><dd><span class={{self.ordinal.rarity()}}>{{ self.ordinal.rarity() }}</span></dd>
-  <dt>block time</dt><dd>{{ self.blocktime }}</dd>
+  <dt>time</dt><dd>{{ self.blocktime }}</dd>
 </dl>
 %% if self.ordinal.n() > 0 {
 <a href=/ordinal/{{self.ordinal.n() - 1}}>prev</a>

--- a/tests/server.rs
+++ b/tests/server.rs
@@ -293,7 +293,7 @@ fn unmined_ordinal() {
   state.request_regex(
     "ordinal/0",
     200,
-    ".*<dt>block time</dt><dd>2011-02-02 23:16:42</dd>.*",
+    ".*<dt>time</dt><dd>2011-02-02 23:16:42</dd>.*",
   );
 }
 
@@ -303,7 +303,7 @@ fn mined_ordinal() {
   state.request_regex(
     "ordinal/5000000000",
     200,
-    ".*<dt>block time</dt><dd>.* \\(expected\\)</dd>.*",
+    ".*<dt>time</dt><dd>.* \\(expected\\)</dd>.*",
   );
 }
 


### PR DESCRIPTION
Height is less understandable than block, and time is unambiguous, so "block time" isn't necessary.