### PR TITLE
added block height to ordinal clock

### DIFF
--- a/src/subcommand/server/templates/clock.rs
+++ b/src/subcommand/server/templates/clock.rs
@@ -2,6 +2,7 @@ use super::*;
 
 #[derive(Display)]
 pub(crate) struct ClockSvg {
+  height: u64,
   hour: f64,
   minute: f64,
   second: f64,
@@ -12,6 +13,7 @@ impl ClockSvg {
     let min = height.min(Epoch::FIRST_POST_SUBSIDY.starting_height());
 
     Self {
+      height: height.n(),
       hour: (min.n() % Epoch::FIRST_POST_SUBSIDY.starting_height().n()) as f64
         / Epoch::FIRST_POST_SUBSIDY.starting_height().n() as f64
         * 360.0,
@@ -84,9 +86,9 @@ mod tests {
   fn foo_svg() {
     assert_regex_match!(
       ClockSvg::new(Height(6929999)).to_string(),
-      r##"<svg.*<line y2="-9" transform="rotate\(359.9999480519481\)"/>
-  <line y2="-13" stroke-width="0.6" transform="rotate\(359.9982857142857\)"/>
-  <line y2="-16" stroke="#d00505" stroke-width="0.2" transform="rotate\(179.82142857142858\)"/>.*</svg>
+      r##"<svg.*<line y2="-18" transform="rotate\(359.9999480519481\)"/>
+  <line y2="-26" stroke-width="1.2" transform="rotate\(359.9982857142857\)"/>
+  <line y2="-32" stroke="#d00505" stroke-width="0.4" transform="rotate\(179.82142857142858\)"/>.*</svg>
 "##,
     );
   }

--- a/templates/clock.svg
+++ b/templates/clock.svg
@@ -1,41 +1,42 @@
-<svg viewBox="-20 -20 40 40" stroke-linecap="round" stroke="black" fill="white" xmlns="http://www.w3.org/2000/svg">
-  <circle r="4000" fill="#dedede" stroke="none"/>
-  <circle r="19" stroke-width="0.2"/>
-  <line y1="-16" y2="-15" stroke-width="0.3" stroke="#d00505"/>
-  <line y1="-16" y2="-15" stroke-width="0.3" transform="rotate(10.90909090909091)"/>
-  <line y1="-16" y2="-15" stroke-width="0.3" transform="rotate(21.81818181818182)"/>
-  <line y1="-16" y2="-15" stroke-width="0.3" transform="rotate(32.72727272727273)"/>
-  <line y1="-16" y2="-15" stroke-width="0.3" transform="rotate(43.63636363636364)"/>
-  <line y1="-16" y2="-15" stroke-width="0.3" transform="rotate(54.54545454545455)"/>
-  <line y1="-16" y2="-15" stroke-width="0.5" transform="rotate(65.45454545454545)"/>
-  <line y1="-16" y2="-15" stroke-width="0.3" transform="rotate(76.36363636363636)"/>
-  <line y1="-16" y2="-15" stroke-width="0.3" transform="rotate(87.27272727272728)"/>
-  <line y1="-16" y2="-15" stroke-width="0.3" transform="rotate(98.18181818181817)"/>
-  <line y1="-16" y2="-15" stroke-width="0.3" transform="rotate(109.0909090909091)"/>
-  <line y1="-16" y2="-15" stroke-width="0.3" transform="rotate(120.0)"/>
-  <line y1="-16" y2="-15" stroke-width="0.5" transform="rotate(130.9090909090909)"/>
-  <line y1="-16" y2="-15" stroke-width="0.3" transform="rotate(141.8181818181818)"/>
-  <line y1="-16" y2="-15" stroke-width="0.3" transform="rotate(152.72727272727272)"/>
-  <line y1="-16" y2="-15" stroke-width="0.3" transform="rotate(163.63636363636363)"/>
-  <line y1="-16" y2="-15" stroke-width="0.3" transform="rotate(174.54545454545456)"/>
-  <line y1="-16" y2="-15" stroke-width="0.3" transform="rotate(185.45454545454544)"/>
-  <line y1="-16" y2="-15" stroke-width="0.5" transform="rotate(196.36363636363635)"/>
-  <line y1="-16" y2="-15" stroke-width="0.3" transform="rotate(207.27272727272728)"/>
-  <line y1="-16" y2="-15" stroke-width="0.3" transform="rotate(218.1818181818182)"/>
-  <line y1="-16" y2="-15" stroke-width="0.3" transform="rotate(229.0909090909091)"/>
-  <line y1="-16" y2="-15" stroke-width="0.3" transform="rotate(240.0)"/>
-  <line y1="-16" y2="-15" stroke-width="0.3" transform="rotate(250.90909090909093)"/>
-  <line y1="-16" y2="-15" stroke-width="0.5" transform="rotate(261.8181818181818)"/>
-  <line y1="-16" y2="-15" stroke-width="0.3" transform="rotate(272.72727272727275)"/>
-  <line y1="-16" y2="-15" stroke-width="0.3" transform="rotate(283.6363636363636)"/>
-  <line y1="-16" y2="-15" stroke-width="0.3" transform="rotate(294.54545454545456)"/>
-  <line y1="-16" y2="-15" stroke-width="0.3" transform="rotate(305.45454545454544)"/>
-  <line y1="-16" y2="-15" stroke-width="0.3" transform="rotate(316.3636363636364)"/>
-  <line y1="-16" y2="-15" stroke-width="0.5" transform="rotate(327.27272727272725)"/>
-  <line y1="-16" y2="-15" stroke-width="0.3" transform="rotate(338.1818181818182)"/>
-  <line y1="-16" y2="-15" stroke-width="0.3" transform="rotate(349.0909090909091)"/>
-  <line y2="-9" transform="rotate({{self.hour}})"/>
-  <line y2="-13" stroke-width="0.6" transform="rotate({{self.minute}})"/>
-  <line y2="-16" stroke="#d00505" stroke-width="0.2" transform="rotate({{self.second}})"/>
-  <circle r="0.7" stroke="#d00505" stroke-width="0.3"/>
+<svg viewBox="-40 -40 80 80" stroke-linecap="round" stroke="black" fill="white" xmlns="http://www.w3.org/2000/svg">
+  <circle r="8000" fill="#dedede" stroke="none"/>
+  <circle r="38" stroke-width="0.4"/>
+  <text y="10%" dominant-baseline="middle" text-anchor="middle" font-weight="1" font-size="10px">{{self.height}}</text>
+  <line y1="-32" y2="-30" stroke-width="0.6" stroke="#d00505"/>
+  <line y1="-32" y2="-30" stroke-width="0.6" transform="rotate(10.90909090909091)"/>
+  <line y1="-32" y2="-30" stroke-width="0.6" transform="rotate(21.81818181818182)"/>
+  <line y1="-32" y2="-30" stroke-width="0.6" transform="rotate(32.72727272727273)"/>
+  <line y1="-32" y2="-30" stroke-width="0.6" transform="rotate(43.63636363636364)"/>
+  <line y1="-32" y2="-30" stroke-width="0.6" transform="rotate(54.54545454545455)"/>
+  <line y1="-32" y2="-30" stroke-width="1.0" transform="rotate(65.45454545454545)"/>
+  <line y1="-32" y2="-30" stroke-width="0.6" transform="rotate(76.36363636363636)"/>
+  <line y1="-32" y2="-30" stroke-width="0.6" transform="rotate(87.27272727272728)"/>
+  <line y1="-32" y2="-30" stroke-width="0.6" transform="rotate(98.18181818181817)"/>
+  <line y1="-32" y2="-30" stroke-width="0.6" transform="rotate(109.0909090909091)"/>
+  <line y1="-32" y2="-30" stroke-width="0.6" transform="rotate(120.0)"/>
+  <line y1="-32" y2="-30" stroke-width="1.0" transform="rotate(130.9090909090909)"/>
+  <line y1="-32" y2="-30" stroke-width="0.6" transform="rotate(141.8181818181818)"/>
+  <line y1="-32" y2="-30" stroke-width="0.6" transform="rotate(152.72727272727272)"/>
+  <line y1="-32" y2="-30" stroke-width="0.6" transform="rotate(163.63636363636363)"/>
+  <line y1="-32" y2="-30" stroke-width="0.6" transform="rotate(174.54545454545456)"/>
+  <line y1="-32" y2="-30" stroke-width="0.6" transform="rotate(185.45454545454544)"/>
+  <line y1="-32" y2="-30" stroke-width="1.0" transform="rotate(196.36363636363635)"/>
+  <line y1="-32" y2="-30" stroke-width="0.6" transform="rotate(207.27272727272728)"/>
+  <line y1="-32" y2="-30" stroke-width="0.6" transform="rotate(218.1818181818182)"/>
+  <line y1="-32" y2="-30" stroke-width="0.6" transform="rotate(229.0909090909091)"/>
+  <line y1="-32" y2="-30" stroke-width="0.6" transform="rotate(240.0)"/>
+  <line y1="-32" y2="-30" stroke-width="0.6" transform="rotate(250.90909090909093)"/>
+  <line y1="-32" y2="-30" stroke-width="1.0" transform="rotate(261.8181818181818)"/>
+  <line y1="-32" y2="-30" stroke-width="0.6" transform="rotate(272.72727272727275)"/>
+  <line y1="-32" y2="-30" stroke-width="0.6" transform="rotate(283.6363636363636)"/>
+  <line y1="-32" y2="-30" stroke-width="0.6" transform="rotate(294.54545454545456)"/>
+  <line y1="-32" y2="-30" stroke-width="0.6" transform="rotate(305.45454545454544)"/>
+  <line y1="-32" y2="-30" stroke-width="0.6" transform="rotate(316.3636363636364)"/>
+  <line y1="-32" y2="-30" stroke-width="1.0" transform="rotate(327.27272727272725)"/>
+  <line y1="-32" y2="-30" stroke-width="0.6" transform="rotate(338.1818181818182)"/>
+  <line y1="-32" y2="-30" stroke-width="0.6" transform="rotate(349.0909090909091)"/>
+  <line y2="-18" transform="rotate({{self.hour}})"/>
+  <line y2="-26" stroke-width="1.2" transform="rotate({{self.minute}})"/>
+  <line y2="-32" stroke="#d00505" stroke-width="0.4" transform="rotate({{self.second}})"/>
+  <circle r="1.4" stroke="#d00505" stroke-width="0.6"/>
 </svg>

--- a/templates/clock.svg
+++ b/templates/clock.svg
@@ -1,42 +1,48 @@
 <svg viewBox="-40 -40 80 80" stroke-linecap="round" stroke="black" fill="white" xmlns="http://www.w3.org/2000/svg">
   <circle r="8000" fill="#dedede" stroke="none"/>
   <circle r="38" stroke-width="0.4"/>
-  <text y="10%" dominant-baseline="middle" text-anchor="middle" font-weight="1" font-size="10px">{{self.height}}</text>
-  <line y1="-32" y2="-30" stroke-width="0.6" stroke="#d00505"/>
-  <line y1="-32" y2="-30" stroke-width="0.6" transform="rotate(10.90909090909091)"/>
-  <line y1="-32" y2="-30" stroke-width="0.6" transform="rotate(21.81818181818182)"/>
-  <line y1="-32" y2="-30" stroke-width="0.6" transform="rotate(32.72727272727273)"/>
-  <line y1="-32" y2="-30" stroke-width="0.6" transform="rotate(43.63636363636364)"/>
-  <line y1="-32" y2="-30" stroke-width="0.6" transform="rotate(54.54545454545455)"/>
-  <line y1="-32" y2="-30" stroke-width="1.0" transform="rotate(65.45454545454545)"/>
-  <line y1="-32" y2="-30" stroke-width="0.6" transform="rotate(76.36363636363636)"/>
-  <line y1="-32" y2="-30" stroke-width="0.6" transform="rotate(87.27272727272728)"/>
-  <line y1="-32" y2="-30" stroke-width="0.6" transform="rotate(98.18181818181817)"/>
-  <line y1="-32" y2="-30" stroke-width="0.6" transform="rotate(109.0909090909091)"/>
-  <line y1="-32" y2="-30" stroke-width="0.6" transform="rotate(120.0)"/>
-  <line y1="-32" y2="-30" stroke-width="1.0" transform="rotate(130.9090909090909)"/>
-  <line y1="-32" y2="-30" stroke-width="0.6" transform="rotate(141.8181818181818)"/>
-  <line y1="-32" y2="-30" stroke-width="0.6" transform="rotate(152.72727272727272)"/>
-  <line y1="-32" y2="-30" stroke-width="0.6" transform="rotate(163.63636363636363)"/>
-  <line y1="-32" y2="-30" stroke-width="0.6" transform="rotate(174.54545454545456)"/>
-  <line y1="-32" y2="-30" stroke-width="0.6" transform="rotate(185.45454545454544)"/>
-  <line y1="-32" y2="-30" stroke-width="1.0" transform="rotate(196.36363636363635)"/>
-  <line y1="-32" y2="-30" stroke-width="0.6" transform="rotate(207.27272727272728)"/>
-  <line y1="-32" y2="-30" stroke-width="0.6" transform="rotate(218.1818181818182)"/>
-  <line y1="-32" y2="-30" stroke-width="0.6" transform="rotate(229.0909090909091)"/>
-  <line y1="-32" y2="-30" stroke-width="0.6" transform="rotate(240.0)"/>
-  <line y1="-32" y2="-30" stroke-width="0.6" transform="rotate(250.90909090909093)"/>
-  <line y1="-32" y2="-30" stroke-width="1.0" transform="rotate(261.8181818181818)"/>
-  <line y1="-32" y2="-30" stroke-width="0.6" transform="rotate(272.72727272727275)"/>
-  <line y1="-32" y2="-30" stroke-width="0.6" transform="rotate(283.6363636363636)"/>
-  <line y1="-32" y2="-30" stroke-width="0.6" transform="rotate(294.54545454545456)"/>
-  <line y1="-32" y2="-30" stroke-width="0.6" transform="rotate(305.45454545454544)"/>
-  <line y1="-32" y2="-30" stroke-width="0.6" transform="rotate(316.3636363636364)"/>
-  <line y1="-32" y2="-30" stroke-width="1.0" transform="rotate(327.27272727272725)"/>
-  <line y1="-32" y2="-30" stroke-width="0.6" transform="rotate(338.1818181818182)"/>
-  <line y1="-32" y2="-30" stroke-width="0.6" transform="rotate(349.0909090909091)"/>
+  <text y="10%" dominant-baseline="middle" text-anchor="middle" font-weight="1" font-size="10px" color="grey">{{self.height}}</text>
+  <line class="ring-marks" y1="-32" y2="-30" stroke-width="0.6" stroke="#d00505"/>
+  <line class="ring-marks" y1="-32" y2="-30" stroke-width="0.6" transform="rotate(10.90909090909091)"><title>1st Halving</title></line>
+  <line class="ring-marks" y1="-32" y2="-30" stroke-width="0.6" transform="rotate(21.81818181818182)"><title>2nd Halving</title></line>
+  <line class="ring-marks" y1="-32" y2="-30" stroke-width="0.6" transform="rotate(32.72727272727273)"><title>3rd Halving</title></line>
+  <line class="ring-marks" y1="-32" y2="-30" stroke-width="0.6" transform="rotate(43.63636363636364)"><title>4th Halving</title></line>
+  <line class="ring-marks" y1="-32" y2="-30" stroke-width="0.6" transform="rotate(54.54545454545455)"><title>5th Halving</title></line>
+  <line class="ring-marks" y1="-32" y2="-30" stroke-width="1.0" transform="rotate(65.45454545454545)"><title>6th Halving (Difficulty Adjustment + Halving)</title></line>
+  <line class="ring-marks" y1="-32" y2="-30" stroke-width="0.6" transform="rotate(76.36363636363636)"><title>7th Halving</title></line>
+  <line class="ring-marks" y1="-32" y2="-30" stroke-width="0.6" transform="rotate(87.27272727272728)"><title>8th Halving</title></line>
+  <line class="ring-marks" y1="-32" y2="-30" stroke-width="0.6" transform="rotate(98.18181818181817)"><title>9th Halving</title></line>
+  <line class="ring-marks" y1="-32" y2="-30" stroke-width="0.6" transform="rotate(109.0909090909091)"><title>10th Halving</title></line>
+  <line class="ring-marks" y1="-32" y2="-30" stroke-width="0.6" transform="rotate(120.0)"><title>11th Halving</title></line>
+  <line class="ring-marks" y1="-32" y2="-30" stroke-width="1.0" transform="rotate(130.9090909090909)"><title>12th Halving (Difficulty Adjustment + Halving)</title></line>
+  <line class="ring-marks" y1="-32" y2="-30" stroke-width="0.6" transform="rotate(141.8181818181818)"><title>13th Halving</title></line>
+  <line class="ring-marks" y1="-32" y2="-30" stroke-width="0.6" transform="rotate(152.72727272727272)"><title>14th Halving</title></line>
+  <line class="ring-marks" y1="-32" y2="-30" stroke-width="0.6" transform="rotate(163.63636363636363)"><title>15th Halving</title></line>
+  <line class="ring-marks" y1="-32" y2="-30" stroke-width="0.6" transform="rotate(174.54545454545456)"><title>16th Halving</title></line>
+  <line class="ring-marks" y1="-32" y2="-30" stroke-width="0.6" transform="rotate(185.45454545454544)"><title>17th Halving</title></line>
+  <line class="ring-marks" y1="-32" y2="-30" stroke-width="1.0" transform="rotate(196.36363636363635)"><title>18th Halving (Difficulty Adjustment + Halving)</title></line>
+  <line class="ring-marks" y1="-32" y2="-30" stroke-width="0.6" transform="rotate(207.27272727272728)"><title>19th Halving</title></line>
+  <line class="ring-marks" y1="-32" y2="-30" stroke-width="0.6" transform="rotate(218.1818181818182)"><title>20th Halving</title></line>
+  <line class="ring-marks" y1="-32" y2="-30" stroke-width="0.6" transform="rotate(229.0909090909091)"><title>21st Halving</title></line>
+  <line class="ring-marks" y1="-32" y2="-30" stroke-width="0.6" transform="rotate(240.0)"><title>22nd Halving</title></line>
+  <line class="ring-marks" y1="-32" y2="-30" stroke-width="0.6" transform="rotate(250.90909090909093)"><title>23rd Halving</title></line>
+  <line class="ring-marks" y1="-32" y2="-30" stroke-width="1.0" transform="rotate(261.8181818181818)"><title>24th Halving (Difficulty Adjustment + Halving)</title></line>
+  <line class="ring-marks" y1="-32" y2="-30" stroke-width="0.6" transform="rotate(272.72727272727275)"><title>25th Halving</title></line>
+  <line class="ring-marks" y1="-32" y2="-30" stroke-width="0.6" transform="rotate(283.6363636363636)"><title>26th Halving</title></line>
+  <line class="ring-marks" y1="-32" y2="-30" stroke-width="0.6" transform="rotate(294.54545454545456)"><title>27th Halving</title></line>
+  <line class="ring-marks" y1="-32" y2="-30" stroke-width="0.6" transform="rotate(305.45454545454544)"><title>28th Halving</title></line>
+  <line class="ring-marks" y1="-32" y2="-30" stroke-width="0.6" transform="rotate(316.3636363636364)"><title>29th Halving</title></line>
+  <line class="ring-marks" y1="-32" y2="-30" stroke-width="1.0" transform="rotate(327.27272727272725)"><title>30th Halving (Difficulty Adjustment + Halving)</title></line>
+  <line class="ring-marks" y1="-32" y2="-30" stroke-width="0.6" transform="rotate(338.1818181818182)"><title>31st Halving</title></line>
+  <line class="ring-marks" y1="-32" y2="-30" stroke-width="0.6" transform="rotate(349.0909090909091)"><title>32nd Halving</title></line>
   <line y2="-18" transform="rotate({{self.hour}})"/>
   <line y2="-26" stroke-width="1.2" transform="rotate({{self.minute}})"/>
   <line y2="-32" stroke="#d00505" stroke-width="0.4" transform="rotate({{self.second}})"/>
   <circle r="1.4" stroke="#d00505" stroke-width="0.6"/>
+
+  <style>
+    .ring-marks:hover {
+      stroke: grey;
+    }
+  </style>
 </svg>

--- a/tests/server.rs
+++ b/tests/server.rs
@@ -352,7 +352,7 @@ fn clock_updates() {
   state.request_regex(
     "clock",
     200,
-    r#".*<line y2="-9" transform="rotate\(0\)"/>.*"#,
+    r#".*<line y2="-18" transform="rotate\(0\)"/>.*"#,
   );
 
   state.blocks(1);
@@ -360,7 +360,7 @@ fn clock_updates() {
   state.request_regex(
     "clock",
     200,
-    r#".*<line y2="-9" transform="rotate\(0.00005194805194805195\)"/>.*"#,
+    r#".*<line y2="-18" transform="rotate\(0.00005194805194805195\)"/>.*"#,
   );
 }
 


### PR DESCRIPTION
This starts work on #386 and #387.

The SVG had to be scaled up (2x for now) because the smallest readable font size is `10px` even with `font-weight="1"`. I haven't made any choices regarding `font-family` but it should probably be some sort of `sans-serif` or `monospace`.

An idea/proposal on how to do <title> explanations. Added some css so people hover over the marker long enough for the explanation to pop up. 

Is is called Halving or Halvening? 