### PR TITLE
Increase default maximum index size for non-regtest chains

### DIFF
--- a/deploy/ord.service
+++ b/deploy/ord.service
@@ -11,7 +11,6 @@ Environment=RUST_LOG=info
 ExecStart=/usr/local/bin/ord \
   --bitcoin-data-dir /var/lib/bitcoind \
   --data-dir /var/lib/ord \
-  --max-index-size 1TiB \
   --chain ${CHAIN} \
   server \
   --acme-contact mailto:casey@rodarmor.com \

--- a/src/bytes.rs
+++ b/src/bytes.rs
@@ -7,8 +7,21 @@ const TI: usize = GI << 10;
 const PI: usize = TI << 10;
 const EI: usize = PI << 10;
 
-#[derive(Debug, Eq, PartialEq)]
+#[derive(Debug, Eq, PartialEq, Copy, Clone)]
 pub(crate) struct Bytes(pub(crate) usize);
+
+impl Bytes {
+  pub(crate) const MIB: Bytes = Bytes(MI);
+  pub(crate) const TIB: Bytes = Bytes(TI);
+}
+
+impl Mul<usize> for Bytes {
+  type Output = Bytes;
+
+  fn mul(self, rhs: usize) -> Self::Output {
+    Bytes(self.0 * rhs)
+  }
+}
 
 impl FromStr for Bytes {
   type Err = Error;
@@ -35,7 +48,7 @@ impl FromStr for Bytes {
       _ => return Err(anyhow!("invalid suffix")),
     };
 
-    Ok(Bytes((value * multiple as f64) as usize))
+    Ok(Bytes((value * multiple as f64).ceil() as usize))
   }
 }
 

--- a/src/index.rs
+++ b/src/index.rs
@@ -44,7 +44,7 @@ impl Index {
       Err(redb::Error::Io(error)) if error.kind() == io::ErrorKind::NotFound => unsafe {
         Database::builder()
           .set_write_strategy(WriteStrategy::Throughput)
-          .create(&database_path, options.max_index_size.0)?
+          .create(&database_path, options.max_index_size().0)?
       },
       Err(error) => return Err(error.into()),
     };

--- a/src/main.rs
+++ b/src/main.rs
@@ -53,7 +53,7 @@ use {
     fmt::{self, Display, Formatter},
     fs, io,
     net::ToSocketAddrs,
-    ops::{Add, AddAssign, Deref, Sub},
+    ops::{Add, AddAssign, Deref, Mul, Sub},
     path::{Path, PathBuf},
     process,
     str::FromStr,


### PR DESCRIPTION
The ordinal index, stored in <ORD_DATA_DIR>/index.redb, is a redb
database, which grows dynamically. However, the maximum size that the
database can grow to must be declared up-front, to avoid expensive
region allocation operations on insert. We've been using 10 MiB as the
default index size, which is too small for anything but testing.

This commit changes the default maximum index size to 1 TiB on mainnet,
testnet, and signet, and leaves it at 10 MiB on regtest. 1 TiB is more
than needed, as even the mainnet database is only ~50 GiB, but
allocating a database is fast enough, so it doesn't hurt to over
provision and not have to think about it. For testing though, which is
done with `--chain=regtest`, we want database allocation is fast, and 10
MiB is more than enough.