### PR TITLE
Document how to turn on logging

### DIFF
--- a/README.md
+++ b/README.md
@@ -116,6 +116,14 @@ If `bitcoind` is not on mainnet, is not run by the same user, has a non-default
 datadir, or a non-default port, you'll need to pass additional flags to `ord`.
 See `ord --help` for details.
 
+### Logging
+
+`ord` uses [env_logger](https://docs.rs/env_logger/latest/env_logger/). Set the `RUST_LOG` environment variable in order to turn on logging. For example, run the server and show `info`-level log messages and above:
+
+```
+$ RUST_LOG=info cargo run server
+```
+
 Index
 -----
 


### PR DESCRIPTION
@raphjaph I wanted to make sure to actually document this, since it's not obvious at all. Logging is actually pretty configurable, since it uses `env_logger`.