### PR TITLE
added blockheight to SVG

### DIFF
--- a/src/subcommand/server/templates/clock.rs
+++ b/src/subcommand/server/templates/clock.rs
@@ -2,6 +2,7 @@ use super::*;
 
 #[derive(Display)]
 pub(crate) struct ClockSvg {
+  height: u64,
   hour: f64,
   minute: f64,
   second: f64,
@@ -12,6 +13,7 @@ impl ClockSvg {
     let min = height.min(Epoch::FIRST_POST_SUBSIDY.starting_height());
 
     Self {
+      height: height.n(),
       hour: (min.n() % Epoch::FIRST_POST_SUBSIDY.starting_height().n()) as f64
         / Epoch::FIRST_POST_SUBSIDY.starting_height().n() as f64
         * 360.0,

--- a/src/subcommand/server/templates/clock.rs
+++ b/src/subcommand/server/templates/clock.rs
@@ -2,7 +2,7 @@ use super::*;
 
 #[derive(Display)]
 pub(crate) struct ClockSvg {
-  height: u64,
+  height: Height,
   hour: f64,
   minute: f64,
   second: f64,
@@ -13,7 +13,7 @@ impl ClockSvg {
     let min = height.min(Epoch::FIRST_POST_SUBSIDY.starting_height());
 
     Self {
-      height: height.n(),
+      height,
       hour: (min.n() % Epoch::FIRST_POST_SUBSIDY.starting_height().n()) as f64
         / Epoch::FIRST_POST_SUBSIDY.starting_height().n() as f64
         * 360.0,

--- a/src/subcommand/server/templates/clock.rs
+++ b/src/subcommand/server/templates/clock.rs
@@ -83,10 +83,11 @@ mod tests {
   }
 
   #[test]
-  fn foo_svg() {
+  fn clock_svg() {
     assert_regex_match!(
       ClockSvg::new(Height(6929999)).to_string(),
-      r##"<svg.*<line y2="-9" transform="rotate\(359.9999480519481\)"/>
+      r##"<svg.*<text.*>6929999</text>.*
+  <line y2="-9" transform="rotate\(359.9999480519481\)"/>
   <line y2="-13" stroke-width="0.6" transform="rotate\(359.9982857142857\)"/>
   <line y2="-16" stroke="#d00505" stroke-width="0.2" transform="rotate\(179.82142857142858\)"/>.*</svg>
 "##,

--- a/templates/clock.svg
+++ b/templates/clock.svg
@@ -1,7 +1,7 @@
 <svg viewBox="-20 -20 40 40" stroke-linecap="round" stroke="black" fill="white" xmlns="http://www.w3.org/2000/svg">
   <circle r="4000" fill="#dedede" stroke="none"/>
   <circle r="19" stroke-width="0.2"/>
-  <text y="10%" dominant-baseline="middle" text-anchor="middle" stroke="none" font-size="4px" font-family="sans-serif" fill="LightGrey">{{self.height}}</text>
+  <text y="4" dominant-baseline="middle" text-anchor="middle" stroke="none" font-size="4" fill="lightgrey">{{self.height}}</text>
   <line y1="-16" y2="-15" stroke-width="0.3" stroke="#d00505"/>
   <line y1="-16" y2="-15" stroke-width="0.3" transform="rotate(10.90909090909091)"/>
   <line y1="-16" y2="-15" stroke-width="0.3" transform="rotate(21.81818181818182)"/>

--- a/templates/clock.svg
+++ b/templates/clock.svg
@@ -1,7 +1,7 @@
 <svg viewBox="-20 -20 40 40" stroke-linecap="round" stroke="black" fill="white" xmlns="http://www.w3.org/2000/svg">
   <circle r="4000" fill="#dedede" stroke="none"/>
   <circle r="19" stroke-width="0.2"/>
-  <text class="blockheight" y="10%" dominant-baseline="middle" text-anchor="middle">{{self.height}}</text>
+  <text y="10%" dominant-baseline="middle" text-anchor="middle" stroke="none" font-size="4px" font-family="sans-serif" fill="LightGrey">{{self.height}}</text>
   <line y1="-16" y2="-15" stroke-width="0.3" stroke="#d00505"/>
   <line y1="-16" y2="-15" stroke-width="0.3" transform="rotate(10.90909090909091)"/>
   <line y1="-16" y2="-15" stroke-width="0.3" transform="rotate(21.81818181818182)"/>
@@ -39,12 +39,4 @@
   <line y2="-13" stroke-width="0.6" transform="rotate({{self.minute}})"/>
   <line y2="-16" stroke="#d00505" stroke-width="0.2" transform="rotate({{self.second}})"/>
   <circle r="0.7" stroke="#d00505" stroke-width="0.3"/>
-  <style>
-    .blockheight {
-        font-weight: 1;
-        font-size: 5px;
-        font-family: sans-serif;
-        fill: grey;
-    }
-  </style>
 </svg>

--- a/templates/clock.svg
+++ b/templates/clock.svg
@@ -1,6 +1,7 @@
 <svg viewBox="-20 -20 40 40" stroke-linecap="round" stroke="black" fill="white" xmlns="http://www.w3.org/2000/svg">
   <circle r="4000" fill="#dedede" stroke="none"/>
   <circle r="19" stroke-width="0.2"/>
+  <text class="blockheight" y="10%" dominant-baseline="middle" text-anchor="middle">{{self.height}}</text>
   <line y1="-16" y2="-15" stroke-width="0.3" stroke="#d00505"/>
   <line y1="-16" y2="-15" stroke-width="0.3" transform="rotate(10.90909090909091)"/>
   <line y1="-16" y2="-15" stroke-width="0.3" transform="rotate(21.81818181818182)"/>
@@ -38,4 +39,12 @@
   <line y2="-13" stroke-width="0.6" transform="rotate({{self.minute}})"/>
   <line y2="-16" stroke="#d00505" stroke-width="0.2" transform="rotate({{self.second}})"/>
   <circle r="0.7" stroke="#d00505" stroke-width="0.3"/>
+  <style>
+    .blockheight {
+        font-weight: 1;
+        font-size: 5px;
+        font-family: sans-serif;
+        fill: grey;
+    }
+  </style>
 </svg>


### PR DESCRIPTION
This PR is just to show that the SVG has to be scaled up because the text element for the block height is squished. I don't know if there is another way to fix the text but I've tried using `font-size="10%"`,`font-size="0.1em"`, `font-size="xx-small"` and `font-size=10px`. I've also specified `font-weight=1` (thinnest possible lettering). 

I think the SVG has to be scaled up 2-3x for the text not to look squished but if there is another solution I'm happy to use that as well.