### PR TITLE
Pass benchmark dir name in justfile recipe

### DIFF
--- a/bin/benchmark
+++ b/bin/benchmark
@@ -2,9 +2,8 @@
 
 set -euxo pipefail
 
-dir=${1:-`git branch --show-current`}
-mkdir $dir
-cd $dir
+mkdir $1
+cd $1
 
 sudo \
   CARGO_PROFILE_RELEASE_DEBUG=true \

--- a/justfile
+++ b/justfile
@@ -98,4 +98,4 @@ flamegraph:
   CARGO_PROFILE_RELEASE_DEBUG=true sudo cargo flamegraph -- index
 
 benchmark dir=`git branch --show-current`:
-  ./bin/benchmark "{{dir}}"
+  ./bin/benchmark '{{dir}}'

--- a/justfile
+++ b/justfile
@@ -97,5 +97,5 @@ graph:
 flamegraph:
   CARGO_PROFILE_RELEASE_DEBUG=true sudo cargo flamegraph -- index
 
-benchmark dir="":
+benchmark dir=`git branch --show-current`:
   ./bin/benchmark {{dir}}

--- a/justfile
+++ b/justfile
@@ -98,4 +98,4 @@ flamegraph:
   CARGO_PROFILE_RELEASE_DEBUG=true sudo cargo flamegraph -- index
 
 benchmark dir=`git branch --show-current`:
-  ./bin/benchmark {{dir}}
+  ./bin/benchmark "{{dir}}"


### PR DESCRIPTION
The way this was being done before relied on `./bin/benchmark {{dir}}` not resulting in an argument being passed when `dir` is `""`, which is a somewhat unintuitive side effect of the way `just` evaluates recipe lines. Changing it so it always passes in  the directory argument.