### PR TITLE
clock as favicon

### DIFF
--- a/src/subcommand/server.rs
+++ b/src/subcommand/server.rs
@@ -108,7 +108,7 @@ impl Server {
         .route("/clock", get(Self::clock))
         .route("/clock.svg", get(Self::clock))
         .route("/faq", get(Self::faq))
-        .route("/favicon.ico", get(Self::favicon))
+        .route("/favicon.ico", get(Self::clock))
         .route("/height", get(Self::height))
         .route("/ordinal/:ordinal", get(Self::ordinal))
         .route("/output/:output", get(Self::output))
@@ -423,10 +423,6 @@ impl Server {
 
   async fn search(search: extract::Query<Search>) -> Redirect {
     Redirect::to(&format!("/ordinal/{}", search.query))
-  }
-
-  async fn favicon() -> impl IntoResponse {
-    Self::static_asset(extract::Path("/favicon.png".to_string())).await
   }
 
   async fn static_asset(extract::Path(path): extract::Path<String>) -> impl IntoResponse {

--- a/templates/clock.svg
+++ b/templates/clock.svg
@@ -10,7 +10,7 @@
         stroke: #f2a900;
     }
   </style>
-  <circle r="4000" fill="#dedede" stroke="none"/>
+  <circle r="4000" fill="none" stroke="none"/>
   <circle r="19" stroke-width="0.2"/>
   <text y="4" dominant-baseline="middle" text-anchor="middle" stroke="none" font-size="4" fill="lightgrey">{{self.height}}</text>
   <line class="mythic" y1="-16" y2="-15" stroke-width="0.3" stroke="#d00505"><title>Genesis</title></line>


### PR DESCRIPTION
Ideally, we want to transform the favicon from an SVG to a PNG so more browsers support it. I tried looking into that but in order to use the same template I have to go into the boilerplate library and understand how all the macro stuff works. Especially because there is axum stuff mixed in there as well.