### PR TITLE
Allow multiple outpoints for list subcommand and amend output format

### DIFF
--- a/src/index.rs
+++ b/src/index.rs
@@ -170,11 +170,9 @@ impl Index {
     let block = loop {
       match self.block_at_height(height) {
         Err(err) => {
-          log::error!("Failed to fetch block {height}: {err}");
-
-          let seconds = 1 << errors;
-
           errors += 1;
+          let seconds = 1 << errors;
+          log::error!("Failed to fetch block {height}, retrying in {seconds}s: {err}");
 
           if seconds > 120 {
             log::error!("Would sleep for more than 120s, giving up");

--- a/src/index.rs
+++ b/src/index.rs
@@ -216,7 +216,7 @@ impl Index {
 
         let ordinal_ranges = outpoint_to_ordinal_ranges
           .get(&key)?
-          .ok_or_else(|| anyhow!("Could not find outpoint in index"))?;
+          .ok_or_else(|| anyhow!("Could not find outpoint {} in index", input.previous_output))?;
 
         for chunk in ordinal_ranges.chunks_exact(11) {
           input_ordinal_ranges.push_back(Self::decode_ordinal_range(chunk.try_into().unwrap()));

--- a/src/index.rs
+++ b/src/index.rs
@@ -140,8 +140,9 @@ impl Index {
         wtx.commit()?;
         let now = Instant::now();
         log::info!(
-          "{}ms elapsed since previous commit, committed up to block {block} in {}ms",
+          "{}ms elapsed since previous commit, committed up to block {} in {}ms",
           (now - last_commit_time).as_millis(),
+          self.height()?.n(),
           (now - commit_start_time).as_millis()
         );
         last_commit_time = Instant::now();
@@ -159,8 +160,9 @@ impl Index {
     wtx.commit()?;
     let now = Instant::now();
     log::info!(
-      "{}ms elapsed since previous commit, final commit up to block {block} in {}ms",
+      "{}ms elapsed since previous commit, final commit up to block {} in {}ms",
       (now - last_commit_time).as_millis(),
+      self.height()?.n(),
       (now - commit_start_time).as_millis()
     );
 

--- a/src/subcommand/list.rs
+++ b/src/subcommand/list.rs
@@ -2,7 +2,7 @@ use super::*;
 
 #[derive(Debug, Parser)]
 pub(crate) struct List {
-  #[clap(long,short,help = "Use extended output format")]
+  #[clap(long, short, help = "Use extended output format")]
   longform: bool,
   outpoints: Vec<OutPoint>,
 }
@@ -19,12 +19,17 @@ impl List {
             println!("{} {}", outpoint, oldest.0);
           }
           for (start, end) in ranges {
-            if self.longform { println!("  [{start},{end})<{}>", end-start) }
-            else { println!("[{start},{end})") }
+            if self.longform {
+              println!("  [{start},{end})<{}>", end - start)
+            } else {
+              println!("[{start},{end})")
+            }
           }
         }
-        Some(crate::index::List::Spent(txid)) => return Err(anyhow!("Output {} spent in transaction {txid}", outpoint)),
-        None => return Err(anyhow!("Output {} not found", outpoint))
+        Some(crate::index::List::Spent(txid)) => {
+          return Err(anyhow!("Output {} spent in transaction {txid}", outpoint))
+        }
+        None => return Err(anyhow!("Output {} not found", outpoint)),
       }
     }
     Ok(())

--- a/src/subcommand/list.rs
+++ b/src/subcommand/list.rs
@@ -2,6 +2,8 @@ use super::*;
 
 #[derive(Debug, Parser)]
 pub(crate) struct List {
+  #[clap(long,short,help = "Use extended output format")]
+  longform: bool,
   outpoints: Vec<OutPoint>,
 }
 
@@ -12,11 +14,13 @@ impl List {
     for outpoint in self.outpoints {
       match index.list(outpoint)? {
         Some(crate::index::List::Unspent(ranges)) => {
-          let oldest = ranges.iter().min_by_key(|sat| sat.0).unwrap();
-          println!("{} {}", outpoint, oldest.0);
+          if self.longform {
+            let oldest = ranges.iter().min_by_key(|sat| sat.0).unwrap();
+            println!("{} {}", outpoint, oldest.0);
+          }
           for (start, end) in ranges {
-            let sats = end - start;
-            println!("  [{start},{end}) <{sats}>");
+            if self.longform { println!("  [{start},{end})<{}>", end-start) }
+            else { println!("[{start},{end})") }
           }
         }
         Some(crate::index::List::Spent(txid)) => return Err(anyhow!("Output {} spent in transaction {txid}", outpoint)),

--- a/templates/home.html
+++ b/templates/home.html
@@ -6,6 +6,7 @@
   <a href=https://github.com/casey/ord/blob/master/bip.mediawiki>BIP</a>
   <a href=https://github.com/casey/ord>GitHub</a>
   <a href=https://discord.gg/87cjuz4FYg>Discord</a>
+  <a href=/clock>Clock</a>
 </nav>
 <h2>Search</h2>
 <form action=/search method=get>


### PR DESCRIPTION
- Allow multiple outpoints for list subcommand.
  This is desirable as loading the index can take a minute or so.
- Introduce `longform` flag for `list` subcommand
- Implement `longform` output format of `list` subcommand:
  For each output, print
    1. outpoint and oldest sat contained
    2. followed by each ordinal range, indented by two spaces, and the size of the range in angle brackets

So an example output for running `ord list -l 59b726ae47b86e7aa512a56590427bf512b4486449f71495611d1a80f935dd0f:0 a7bbee795740d9d5218e82891eca7cf90fd4a394e5aebf29fe8bb68f30086ece:0` (current leading submission to ordinals bounty 1 at http://ordinals.com/bounties and a random unspent recent coinbase output):
```
59b726ae47b86e7aa512a56590427bf512b4486449f71495611d1a80f935dd0f:0 2317234675546
  [2317234675546,2317234676101) <555>
a7bbee795740d9d5218e82891eca7cf90fd4a394e5aebf29fe8bb68f30086ece:0 18102122814452
  [1912498125000000,1912498750000000) <625000000>
  [1620797051291245,1620797051325925) <34680>
  [1594563279555990,1594563279592863) <36873>
  [1011026980945471,1011026980965471) <20000>
  [1513920605064311,1513920605075633) <11322>
  [1673929501375221,1673929501384149) <8928>
  [1654916672313606,1654916672317064) <3458>
  ...
  [1129605685531348,1129605685531459) <111>
  [1894361844736252,1894361844736393) <141>
  [1534978183583197,1534978183583496) <299>
  [964653666886123,964653666886362) <239>
```

Will probably iterate on this format, but this is easily human readable and allows finding the oldest ordinal given a list of outputs in `my-outputs.txt` with one simple command line:
```
xargs ord list -l < my-outputs.txt | grep -v '^  ' | sort -n +1 | head -1
```

If you have an Electrum wallet, you can easily get a list of all the outputs you control by running
```
for o in map(lambda x:x.get('prevout_hash')+':'+str(x.get('prevout_n')), listunspent()):
  print(o)
```