### PR TITLE
Use fixed-size types for database keys and values.

### DIFF
--- a/src/index.rs
+++ b/src/index.rs
@@ -9,9 +9,10 @@ use {
 mod rtx;
 
 const HEIGHT_TO_HASH: TableDefinition<u64, [u8]> = TableDefinition::new("HEIGHT_TO_HASH");
-const OUTPOINT_TO_ORDINAL_RANGES: TableDefinition<[u8], [u8]> =
+const OUTPOINT_TO_ORDINAL_RANGES: TableDefinition<[u8; 36], [u8]> =
   TableDefinition::new("OUTPOINT_TO_ORDINAL_RANGES");
-const OUTPOINT_TO_TXID: TableDefinition<[u8], [u8]> = TableDefinition::new("OUTPOINT_TO_TXID");
+const OUTPOINT_TO_TXID: TableDefinition<[u8; 36], [u8; 32]> =
+  TableDefinition::new("OUTPOINT_TO_TXID");
 
 pub(crate) struct Index {
   client: Client,
@@ -227,7 +228,7 @@ impl Index {
       let mut input_ordinal_ranges = VecDeque::new();
 
       for input in &tx.input {
-        let key = serialize(&input.previous_output);
+        let key = serialize(&input.previous_output).try_into().unwrap();
 
         let ordinal_ranges = outpoint_to_ordinal_ranges
           .get(&key)?
@@ -305,8 +306,8 @@ impl Index {
     &self,
     txid: Txid,
     tx: &Transaction,
-    outpoint_to_ordinal_ranges: &mut Table<[u8], [u8]>,
-    #[allow(unused)] outpoint_to_txid: &mut Table<[u8], [u8]>,
+    outpoint_to_ordinal_ranges: &mut Table<[u8; 36], [u8]>,
+    #[allow(unused)] outpoint_to_txid: &mut Table<[u8; 36], [u8; 32]>,
     input_ordinal_ranges: &mut VecDeque<(u64, u64)>,
     ordinal_ranges_written: &mut u64,
   ) -> Result {
@@ -345,7 +346,7 @@ impl Index {
         *ordinal_ranges_written += 1;
       }
 
-      outpoint_to_ordinal_ranges.insert(&serialize(&outpoint), &ordinals)?;
+      outpoint_to_ordinal_ranges.insert(&serialize(&outpoint).try_into().unwrap(), &ordinals)?;
     }
 
     #[cfg(any())]
@@ -409,14 +410,19 @@ impl Index {
 
     let outpoint_to_ordinal_ranges = rtx.open_table(OUTPOINT_TO_ORDINAL_RANGES)?;
 
-    let mut cursor = outpoint_to_ordinal_ranges.range([]..)?;
+    let mut cursor = outpoint_to_ordinal_ranges.range(
+      [
+        0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+        0, 0, 0, 0, 0, 0,
+      ]..,
+    )?;
 
     while let Some((key, value)) = cursor.next() {
       let mut offset = 0;
       for chunk in value.chunks_exact(11) {
         let (start, end) = Index::decode_ordinal_range(chunk.try_into().unwrap());
         if start <= ordinal.0 && ordinal.0 < end {
-          let outpoint: OutPoint = Decodable::consensus_decode(key)?;
+          let outpoint: OutPoint = Decodable::consensus_decode(key.as_slice())?;
           return Ok(Some(SatPoint {
             outpoint,
             offset: offset + ordinal.0 - start,
@@ -435,7 +441,7 @@ impl Index {
         .database
         .begin_read()?
         .open_table(OUTPOINT_TO_ORDINAL_RANGES)?
-        .get(outpoint)?
+        .get(outpoint.try_into().unwrap())?
         .map(|outpoint| outpoint.to_vec()),
     )
   }
@@ -457,8 +463,8 @@ impl Index {
           .database
           .begin_read()?
           .open_table(OUTPOINT_TO_TXID)?
-          .get(&outpoint_encoded)?
-          .map(Txid::consensus_decode)
+          .get(&outpoint_encoded.try_into().unwrap())?
+          .map(|txid| Txid::consensus_decode(txid.as_slice()))
           .transpose()?
           .map(List::Spent),
       ),

--- a/src/index.rs
+++ b/src/index.rs
@@ -410,12 +410,7 @@ impl Index {
 
     let outpoint_to_ordinal_ranges = rtx.open_table(OUTPOINT_TO_ORDINAL_RANGES)?;
 
-    let mut cursor = outpoint_to_ordinal_ranges.range(
-      [
-        0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
-        0, 0, 0, 0, 0, 0,
-      ]..,
-    )?;
+    let mut cursor = outpoint_to_ordinal_ranges.range([0; 36]..)?;
 
     while let Some((key, value)) = cursor.next() {
       let mut offset = 0;


### PR DESCRIPTION
Fixes #417. I want to double check first that redb implements the fixed-size optimization for byte arrays.