### PR TITLE
Allow multiple outpoints for list subcommand and introduce longform flag for list

### DIFF
--- a/src/subcommand/list.rs
+++ b/src/subcommand/list.rs
@@ -2,22 +2,36 @@ use super::*;
 
 #[derive(Debug, Parser)]
 pub(crate) struct List {
-  outpoint: OutPoint,
+  #[clap(long, short, help = "Use extended output format")]
+  longform: bool,
+  outpoints: Vec<OutPoint>,
 }
 
 impl List {
   pub(crate) fn run(self, options: Options) -> Result<()> {
     let index = Index::index(&options)?;
 
-    match index.list(self.outpoint)? {
-      Some(crate::index::List::Unspent(ranges)) => {
-        for (start, end) in ranges {
-          println!("[{start},{end})");
+    for outpoint in self.outpoints {
+      match index.list(outpoint)? {
+        Some(crate::index::List::Unspent(ranges)) => {
+          if self.longform {
+            let oldest = ranges.iter().min_by_key(|sat| sat.0).unwrap();
+            println!("{} {}", outpoint, oldest.0);
+          }
+          for (start, end) in ranges {
+            if self.longform {
+              println!("  [{start},{end})<{}>", end - start)
+            } else {
+              println!("[{start},{end})")
+            }
+          }
         }
-        Ok(())
+        Some(crate::index::List::Spent(txid)) => {
+          return Err(anyhow!("Output {} spent in transaction {txid}", outpoint))
+        }
+        None => return Err(anyhow!("Output {} not found", outpoint)),
       }
-      Some(crate::index::List::Spent(txid)) => Err(anyhow!("Output spent in transaction {txid}")),
-      None => Err(anyhow!("Output not found")),
     }
+    Ok(())
   }
 }


### PR DESCRIPTION
- Allow multiple outpoints for list subcommand
- Introduce `longform` flag for `list` subcommand, with following output format:
  For each output, we
  1. Print outpoint and oldest sat contained
  2. Followed by each ordinal range, indented by two spaces, and the size of the range

So an example output for running `ord list -l 59b726ae47b86e7aa512a56590427bf512b4486449f71495611d1a80f935dd0f:0 a7bbee795740d9d5218e82891eca7cf90fd4a394e5aebf29fe8bb68f30086ece:0` (current leading submission to ordinals bounty 1 at http://ordinals.com/bounties and a random unspent recent coinbase output):
```
59b726ae47b86e7aa512a56590427bf512b4486449f71495611d1a80f935dd0f:0 2317234675546
  [2317234675546,2317234676101) <555>
a7bbee795740d9d5218e82891eca7cf90fd4a394e5aebf29fe8bb68f30086ece:0 18102122814452
  [1912498125000000,1912498750000000) <625000000>
  [1620797051291245,1620797051325925) <34680>
  [1594563279555990,1594563279592863) <36873>
  [1011026980945471,1011026980965471) <20000>
  [1513920605064311,1513920605075633) <11322>
  [1673929501375221,1673929501384149) <8928>
  [1654916672313606,1654916672317064) <3458>
  ...
  [1129605685531348,1129605685531459) <111>
  [1894361844736252,1894361844736393) <141>
  [1534978183583197,1534978183583496) <299>
  [964653666886123,964653666886362) <239>
```

Will probably iterate on this format, but this is easily human readable and allows finding the oldest ordinal given a list of outputs in `my-outputs.txt` with one simple command line:
```
xargs ord list -l < my-outputs.txt | grep -v '^  ' | sort -n +1 | head -1
```

If you have an Electrum wallet, you can easily get a list of all the outputs you control by running
```
for o in map(lambda x:x.get('prevout_hash')+':'+str(x.get('prevout_n')), listunspent()):
  print(o)
```