### PR TITLE
Collect and log more timing information (issue #500)

### DIFF
--- a/src/subcommand/list.rs
+++ b/src/subcommand/list.rs
@@ -2,22 +2,36 @@ use super::*;
 
 #[derive(Debug, Parser)]
 pub(crate) struct List {
-  outpoint: OutPoint,
+  #[clap(long, short, help = "Use extended output format")]
+  longform: bool,
+  outpoints: Vec<OutPoint>,
 }
 
 impl List {
   pub(crate) fn run(self, options: Options) -> Result<()> {
     let index = Index::index(&options)?;
 
-    match index.list(self.outpoint)? {
-      Some(crate::index::List::Unspent(ranges)) => {
-        for (start, end) in ranges {
-          println!("[{start},{end})");
+    for outpoint in self.outpoints {
+      match index.list(outpoint)? {
+        Some(crate::index::List::Unspent(ranges)) => {
+          if self.longform {
+            let oldest = ranges.iter().min_by_key(|sat| sat.0).unwrap();
+            println!("{} {}", outpoint, oldest.0);
+          }
+          for (start, end) in ranges {
+            if self.longform {
+              println!("  [{start},{end})<{}>", end - start)
+            } else {
+              println!("[{start},{end})")
+            }
+          }
         }
-        Ok(())
+        Some(crate::index::List::Spent(txid)) => {
+          return Err(anyhow!("Output {} spent in transaction {txid}", outpoint))
+        }
+        None => return Err(anyhow!("Output {} not found", outpoint)),
       }
-      Some(crate::index::List::Spent(txid)) => Err(anyhow!("Output spent in transaction {txid}")),
-      None => Err(anyhow!("Output not found")),
     }
+    Ok(())
   }
 }


### PR DESCRIPTION
Collect more timing info as per #500 

Collect and log:
- time elapsed for database commit
- time elapsed for updating (=indexing to) database/btree in between commits