### PR TITLE
Store and count the total number of outputs traversed when building the index

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -615,6 +615,8 @@ dependencies = [
 [[package]]
 name = "boilerplate"
 version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5eea9ab3a1bd92007c73dfba0ab14e56d2ec6ac2e4e2e5b14b4e4a477a97d311"
 dependencies = [
  "darling",
  "mime",
@@ -1084,9 +1086,9 @@ dependencies = [
 
 [[package]]
 name = "env_logger"
-version = "0.9.0"
+version = "0.9.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0b2cf0344971ee6c64c31be0d530793fba457d322dfec2810c453d0ef228f9c3"
+checksum = "c90bf5f19754d10198ccb95b70664fc925bd1fc090a0fd9a6ebc54acc8cd6272"
 dependencies = [
  "atty",
  "humantime",
@@ -1804,9 +1806,9 @@ checksum = "e2abad23fbc42b3700f2f279844dc832adb2b2eb069b2df918f455c4e18cc646"
 
 [[package]]
 name = "libc"
-version = "0.2.132"
+version = "0.2.133"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8371e4e5341c3a96db127eb2465ac681ced4c433e01dd0e938adbef26ba93ba5"
+checksum = "c0f80d65747a3e43d1596c7c5492d95d5edddaabd45a7fcdb02b95f644164966"
 
 [[package]]
 name = "libsqlite3-sys"
@@ -3235,9 +3237,9 @@ checksum = "6bdef32e8150c2a081110b42772ffe7d7c9032b606bc226c8260fd97e0976601"
 
 [[package]]
 name = "syn"
-version = "1.0.99"
+version = "1.0.100"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "58dbef6ec655055e20b86b15a8cc6d439cca19b667537ac6a1369572d151ab13"
+checksum = "52205623b1b0f064a4e71182c3b18ae902267282930c6d5462c91b859668426e"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -3447,9 +3449,9 @@ dependencies = [
 
 [[package]]
 name = "tokio-stream"
-version = "0.1.9"
+version = "0.1.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "df54d54117d6fdc4e4fea40fe1e4e566b3505700e148a6827e59b34b0d2600d9"
+checksum = "f6edf2d6bc038a43d31353570e27270603f4648d18f5ed10c0e179abe43255af"
 dependencies = [
  "futures-core",
  "pin-project-lite",

--- a/src/index.rs
+++ b/src/index.rs
@@ -28,8 +28,14 @@ pub(crate) enum List {
 }
 
 #[repr(u64)]
-enum Statistics {
+enum Statistic {
   OutputsTraversed = 0,
+}
+
+impl From<Statistic> for u64 {
+  fn from(statistic: Statistic) -> Self {
+    statistic as u64
+  }
 }
 
 impl Index {
@@ -96,8 +102,10 @@ impl Index {
 
     let utxos_indexed = wtx.open_table(OUTPOINT_TO_ORDINAL_RANGES)?.len()?;
 
-    let key = Statistics::OutputsTraversed as u64;
-    let outputs_traversed = wtx.open_table(STATISTICS)?.get(&key)?.unwrap_or(0);
+    let outputs_traversed = wtx
+      .open_table(STATISTICS)?
+      .get(&Statistic::OutputsTraversed.into())?
+      .unwrap_or(0);
 
     let stats = wtx.stats()?;
 
@@ -282,9 +290,9 @@ impl Index {
     height_to_hash.insert(&height, &block.block_hash())?;
 
     statistics.insert(
-      &(Statistics::OutputsTraversed as u64),
+      &Statistic::OutputsTraversed.into(),
       &(statistics
-        .get(&(Statistics::OutputsTraversed as u64))?
+        .get(&(Statistic::OutputsTraversed.into()))?
         .unwrap_or(0)
         + outputs_in_block),
     )?;

--- a/src/index.rs
+++ b/src/index.rs
@@ -90,13 +90,13 @@ impl Index {
       .map(|(height, _hash)| height + 1)
       .unwrap_or(0);
 
-    let outputs_indexed = wtx.open_table(OUTPOINT_TO_ORDINAL_RANGES)?.len()?;
+    let utxos_indexed = wtx.open_table(OUTPOINT_TO_ORDINAL_RANGES)?.len()?;
     // Double unwrap, let's go !!
     let outputs_traversed = wtx.open_table(OUTPUTS_TRAVERSED)?.get(&0).unwrap().unwrap();
     let stats = wtx.stats()?;
 
     println!("blocks indexed: {}", blocks_indexed);
-    println!("outputs indexed: {}", outputs_indexed);
+    println!("utxos indexed: {}", utxos_indexed);
     println!("outputs traversed: {}", outputs_traversed);
     println!("tree height: {}", stats.tree_height());
     println!("free pages: {}", stats.free_pages());

--- a/tests/info.rs
+++ b/tests/info.rs
@@ -9,7 +9,8 @@ fn basic() {
     .stdout_regex(
       r"
         blocks indexed: 1
-        outputs indexed: 1
+        utxos indexed: 1
+        outputs traversed: 1
         tree height: \d+
         free pages: \d+
         stored: .*


### PR DESCRIPTION
I'm unsure about how to properly store a single value persistently in the database. In its own table? What should the key be? Or I make a table HEIGHT_TO_NUM_OUTPUTS that tracks how many outputs there are per block and then I just add up those values in the `info` command?

#487 