### PR TITLE
Update index in `Index::open`

### DIFF
--- a/src/index.rs
+++ b/src/index.rs
@@ -79,19 +79,14 @@ impl Index {
 
     tx.commit()?;
 
-    Ok(Self {
+    let index = Self {
       client,
       database,
       database_path,
       height_limit: options.height_limit,
-    })
-  }
+    };
 
-  #[allow(clippy::self_named_constructors)]
-  pub(crate) fn index(options: &Options) -> Result<Self> {
-    let index = Self::open(options)?;
-
-    index.index_ranges()?;
+    index.index()?;
 
     Ok(index)
   }
@@ -148,7 +143,7 @@ impl Index {
     (base, base + delta)
   }
 
-  pub(crate) fn index_ranges(&self) -> Result {
+  pub(crate) fn index(&self) -> Result {
     let mut wtx = self.database.begin_write()?;
 
     let height = wtx
@@ -572,8 +567,6 @@ mod tests {
 
       let index = Index::open(&options).unwrap();
 
-      index.index_ranges().unwrap();
-
       assert_eq!(index.height().unwrap(), 0);
     }
 
@@ -597,8 +590,6 @@ mod tests {
       .unwrap();
 
       let index = Index::open(&options).unwrap();
-
-      index.index_ranges().unwrap();
 
       assert_eq!(index.height().unwrap(), 1);
     }

--- a/src/subcommand/find.rs
+++ b/src/subcommand/find.rs
@@ -7,7 +7,7 @@ pub(crate) struct Find {
 
 impl Find {
   pub(crate) fn run(self, options: Options) -> Result<()> {
-    let index = Index::index(&options)?;
+    let index = Index::open(&options)?;
 
     match index.find(self.ordinal)? {
       Some(satpoint) => {

--- a/src/subcommand/index.rs
+++ b/src/subcommand/index.rs
@@ -1,6 +1,6 @@
 use super::*;
 
 pub(crate) fn run(options: Options) -> Result<()> {
-  Index::index(&options)?;
+  Index::open(&options)?;
   Ok(())
 }

--- a/src/subcommand/list.rs
+++ b/src/subcommand/list.rs
@@ -7,7 +7,7 @@ pub(crate) struct List {
 
 impl List {
   pub(crate) fn run(self, options: Options) -> Result<()> {
-    let index = Index::index(&options)?;
+    let index = Index::open(&options)?;
 
     match index.list(self.outpoint)? {
       Some(crate::index::List::Unspent(ranges)) => {

--- a/src/subcommand/server.rs
+++ b/src/subcommand/server.rs
@@ -95,7 +95,7 @@ impl Server {
 
       let clone = index.clone();
       thread::spawn(move || loop {
-        if let Err(error) = clone.index_ranges() {
+        if let Err(error) = clone.index() {
           log::error!("{error}");
         }
         thread::sleep(Duration::from_millis(100));

--- a/src/subcommand/wallet/identify.rs
+++ b/src/subcommand/wallet/identify.rs
@@ -3,7 +3,7 @@ use super::*;
 pub(crate) fn run(options: Options) -> Result {
   let purse = Purse::load(&options)?;
 
-  let index = Index::index(&options)?;
+  let index = Index::open(&options)?;
 
   let mut ordinals = purse
     .wallet

--- a/src/subcommand/wallet/send.rs
+++ b/src/subcommand/wallet/send.rs
@@ -12,7 +12,7 @@ impl Send {
   pub(crate) fn run(self, options: Options) -> Result {
     let purse = Purse::load(&options)?;
 
-    let index = Index::index(&options)?;
+    let index = Index::open(&options)?;
 
     let utxo = purse.find(&index, self.ordinal)?;
 


### PR DESCRIPTION
It's never useful to have an unsynced index, so do it on open, and rename `Index::index_ranges` to just `Index::index`.