### PR TITLE
Update redb version to 0.7.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2625,8 +2625,9 @@ dependencies = [
 
 [[package]]
 name = "redb"
-version = "0.6.1"
-source = "git+https://github.com/casey/redb.git?branch=add-write-lock#36a470cc077f2ce88a678bfaa525823591d97206"
+version = "0.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "13f72b3033d337029766b2386c17a89038a7b12d9b243f90004ff76f197acd4e"
 dependencies = [
  "libc",
  "pyo3-build-config",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -27,7 +27,7 @@ lazy_static = "1.4.0"
 log = "0.4.14"
 mime_guess = "2.0.4"
 rayon = "1.5.1"
-redb = { version = "0.6.0", git = "https://github.com/casey/redb.git", branch = "add-write-lock" }
+redb = "0.7.0"
 regex = "1.6.0"
 rust-embed = "6.4.0"
 rustls = "0.20.6"


### PR DESCRIPTION
Building `ord` was failing with:
```
cargo build
    Updating git repository `https://github.com/casey/redb.git`
error: failed to get `redb` as a dependency of package `ord v0.0.3 (/home/satoshi/code/ord)`

Caused by:
  failed to load source for dependency `redb`

Caused by:
  Unable to update https://github.com/casey/redb.git?branch=add-write-lock#36a470cc
```

Looks like that branch was merged into the main `redb` repo and was automatically deleted, and `0.7.0` was released which includes the changes from the branch.