### PR TITLE
Ignore temporary directory

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,3 +6,4 @@
 /index.redb
 /ord.log
 /target
+/tmp


### PR DESCRIPTION
`tmp` is created by the `release` recipe, this just adds it to `.gitignore`.