### PR TITLE
Fix bounty links

### DIFF
--- a/docs/content/bounty/0.md
+++ b/docs/content/bounty/0.md
@@ -11,9 +11,9 @@ Criteria
 
 Send an ordinal whose number ends with a zero to the submission address:
 
-✅: [1857578125803250](/ordinal/1857578125803250)
+✅: [1857578125803250](https://ordinals.com/ordinal/1857578125803250)
 
-❌: [1857578125803251](/ordinal/1857578125803251)
+❌: [1857578125803251](https://ordinals.com/ordinal/1857578125803251)
 
 The ordinal must be the first ordinal of the output you send.
 

--- a/docs/content/bounty/2.md
+++ b/docs/content/bounty/2.md
@@ -11,9 +11,9 @@ Criteria
 
 Send an <span class=uncommon>uncommon</span> ordinal to the submission address:
 
-✅: [347100000000000](/ordinal/347100000000000)
+✅: [347100000000000](https://ordinals.com/ordinal/347100000000000)
 
-❌: [6685000001337](/ordinal/6685000001337)
+❌: [6685000001337](https://ordinals.com/ordinal/6685000001337)
 
 Confirm that the submission address has not received transactions before submitting your entry. Only the first successful submission will be rewarded.
 


### PR DESCRIPTION
Since the bounties are now on a different domain, they need full URLs to any URLs on ordinals.com