### PR TITLE
Sort ordinal properties

### DIFF
--- a/src/subcommand/server/templates/ordinal.rs
+++ b/src/subcommand/server/templates/ordinal.rs
@@ -29,6 +29,7 @@ mod tests {
         <dl>
           <dt>decimal</dt><dd>0.0</dd>
           <dt>degree</dt><dd>0°0′0″0‴</dd>
+          <dt>percentile</dt><dd>0%</dd>
           <dt>name</dt><dd>nvtdijuwxlp</dd>
           <dt>cycle</dt><dd>0</dd>
           <dt>epoch</dt><dd>0</dd>
@@ -38,7 +39,6 @@ mod tests {
           <dt>rarity</dt><dd><span class=mythic>mythic</span></dd>
           <dt>prime</dt><dd>false</dd>
           <dt>time</dt><dd>1970-01-01 00:00:00</dd>
-          <dt>percentile</dt><dd>0%</dd>
         </dl>
         <a>prev</a>
         <a href=/ordinal/1>next</a>
@@ -72,6 +72,7 @@ mod tests {
         <dl>
           <dt>decimal</dt><dd>0.1</dd>
           <dt>degree</dt><dd>0°0′0″1‴</dd>
+          <dt>percentile</dt><dd>0.000000000000047619047671428595%</dd>
           <dt>name</dt><dd>nvtdijuwxlo</dd>
           <dt>cycle</dt><dd>0</dd>
           <dt>epoch</dt><dd>0</dd>
@@ -81,7 +82,6 @@ mod tests {
           <dt>rarity</dt><dd><span class=common>common</span></dd>
           <dt>prime</dt><dd>false</dd>
           <dt>time</dt><dd>1970-01-01 00:00:00</dd>
-          <dt>percentile</dt><dd>0.000000000000047619047671428595%</dd>
         </dl>
         <a href=/ordinal/0>prev</a>
         <a href=/ordinal/2>next</a>

--- a/src/subcommand/server/templates/ordinal.rs
+++ b/src/subcommand/server/templates/ordinal.rs
@@ -30,10 +30,10 @@ mod tests {
           <dt>decimal</dt><dd>0.0</dd>
           <dt>degree</dt><dd>0°0′0″0‴</dd>
           <dt>name</dt><dd>nvtdijuwxlp</dd>
-          <dt>block</dt><dd>0</dd>
           <dt>cycle</dt><dd>0</dd>
           <dt>epoch</dt><dd>0</dd>
           <dt>period</dt><dd>0</dd>
+          <dt>block</dt><dd>0</dd>
           <dt>offset</dt><dd>0</dd>
           <dt>rarity</dt><dd><span class=mythic>mythic</span></dd>
           <dt>prime</dt><dd>false</dd>
@@ -73,10 +73,10 @@ mod tests {
           <dt>decimal</dt><dd>0.1</dd>
           <dt>degree</dt><dd>0°0′0″1‴</dd>
           <dt>name</dt><dd>nvtdijuwxlo</dd>
-          <dt>block</dt><dd>0</dd>
           <dt>cycle</dt><dd>0</dd>
           <dt>epoch</dt><dd>0</dd>
           <dt>period</dt><dd>0</dd>
+          <dt>block</dt><dd>0</dd>
           <dt>offset</dt><dd>1</dd>
           <dt>rarity</dt><dd><span class=common>common</span></dd>
           <dt>prime</dt><dd>false</dd>

--- a/templates/ordinal.html
+++ b/templates/ordinal.html
@@ -2,6 +2,7 @@
 <dl>
   <dt>decimal</dt><dd>{{ self.ordinal.decimal() }}</dd>
   <dt>degree</dt><dd>{{ self.ordinal.degree() }}</dd>
+  <dt>percentile</dt><dd>{{ self.ordinal.percentile() }}</dd>
   <dt>name</dt><dd>{{ self.ordinal.name() }}</dd>
   <dt>cycle</dt><dd>{{ self.ordinal.cycle() }}</dd>
   <dt>epoch</dt><dd>{{ self.ordinal.epoch() }}</dd>
@@ -11,7 +12,6 @@
   <dt>rarity</dt><dd><span class={{self.ordinal.rarity()}}>{{ self.ordinal.rarity() }}</span></dd>
   <dt>prime</dt><dd>{{ self.ordinal.prime() }}</dd>
   <dt>time</dt><dd>{{ self.blocktime }}</dd>
-  <dt>percentile</dt><dd>{{ self.ordinal.percentile() }}</dd>
 </dl>
 %% if self.ordinal.n() > 0 {
 <a href=/ordinal/{{self.ordinal.n() - 1}}>prev</a>

--- a/templates/ordinal.html
+++ b/templates/ordinal.html
@@ -3,10 +3,10 @@
   <dt>decimal</dt><dd>{{ self.ordinal.decimal() }}</dd>
   <dt>degree</dt><dd>{{ self.ordinal.degree() }}</dd>
   <dt>name</dt><dd>{{ self.ordinal.name() }}</dd>
-  <dt>block</dt><dd>{{ self.ordinal.height() }}</dd>
   <dt>cycle</dt><dd>{{ self.ordinal.cycle() }}</dd>
   <dt>epoch</dt><dd>{{ self.ordinal.epoch() }}</dd>
   <dt>period</dt><dd>{{ self.ordinal.period() }}</dd>
+  <dt>block</dt><dd>{{ self.ordinal.height() }}</dd>
   <dt>offset</dt><dd>{{ self.ordinal.third() }}</dd>
   <dt>rarity</dt><dd><span class={{self.ordinal.rarity()}}>{{ self.ordinal.rarity() }}</span></dd>
   <dt>prime</dt><dd>{{ self.ordinal.prime() }}</dd>


### PR DESCRIPTION
Fixes #400. Order time-based properties from least frequent to most frequent. Also group percentile with decimal/degree/name, because like them, it unambiguously refers to an ordinal.