### PR TITLE
Add status header to homepage

### DIFF
--- a/src/subcommand/server.rs
+++ b/src/subcommand/server.rs
@@ -1054,12 +1054,14 @@ mod tests {
     ".*<title>Ordinals</title>.*<h1>Ordinals</h1>
 <nav>.*</nav>
 .*
-<h2>Latest Blocks</h2>
+<h2>Status</h2>
 <dl>
   <dt>cycle</dt><dd>0</dd>
   <dt>epoch</dt><dd>0</dd>
   <dt>period</dt><dd>0</dd>
+  <dt>block</dt><dd>1</dd>
 </dl>
+<h2>Latest Blocks</h2>
 <ol start=1 reversed class='blocks monospace'>
   <li><a href=/block/[[:xdigit:]]{64} class=uncommon>[[:xdigit:]]{64}</a></li>
   <li><a href=/block/000000000019d6689c085ae165831e934ff763ae46a2a6c172b3f1b60a8ce26f class=mythic>000000000019d6689c085ae165831e934ff763ae46a2a6c172b3f1b60a8ce26f</a></li>

--- a/src/subcommand/server/templates/home.rs
+++ b/src/subcommand/server/templates/home.rs
@@ -58,12 +58,14 @@ mod tests {
 <nav>.*</nav>
 <h2>Search</h2>
 <form action=/search method=get>.*</form>
-<h2>Latest Blocks</h2>
+<h2>Status</h2>
 <dl>
   <dt>cycle</dt><dd>1</dd>
   <dt>epoch</dt><dd>6</dd>
   <dt>period</dt><dd>625</dd>
+  <dt>block</dt><dd>1260001</dd>
 </dl>
+<h2>Latest Blocks</h2>
 <ol start=1260001 reversed class='blocks monospace'>
   <li><a href=/block/1{64} class=uncommon>1{64}</a></li>
   <li><a href=/block/0{64} class=legendary>0{64}</a></li>

--- a/templates/home.html
+++ b/templates/home.html
@@ -14,14 +14,16 @@
   <input autocapitalize=off autocomplete=off autocorrect=off autofocus name=query spellcheck=false type=text>
   <input type=submit>
 </form>
-<h2>Latest Blocks</h2>
 %% if let Some(starting_ordinal) = self.starting_ordinal {
+<h2>Status</h2>
 <dl>
   <dt>cycle</dt><dd>{{starting_ordinal.cycle()}}</dd>
   <dt>epoch</dt><dd>{{starting_ordinal.epoch()}}</dd>
   <dt>period</dt><dd>{{starting_ordinal.period()}}</dd>
+  <dt>block</dt><dd>{{starting_ordinal.height()}}</dd>
 </dl>
 %% }
+<h2>Latest Blocks</h2>
 <ol start={{self.last}} reversed class='blocks monospace'>
 %% for (rarity, hash) in &self.blocks {
   <li><a href=/block/{{hash}} class={{rarity}}>{{hash}}</a></li>


### PR DESCRIPTION
The additional information looks a little better under a dedicate header:


<img width="760" alt="Screen Shot 2022-10-04 at 6 12 35 PM" src="https://user-images.githubusercontent.com/1945/193958355-36577cd5-c001-4126-ab3b-24217d4c1b0a.png">
