### PR TITLE
Remove multilingual book config key

### DIFF
--- a/book/book.toml
+++ b/book/book.toml
@@ -1,7 +1,6 @@
 [book]
 title = "Ordinal Hunter's Manual"
 language = "en"
-multilingual = false
 src = "src"
 
 [build]


### PR DESCRIPTION
I don't think this actually does anything, not sure why I added it.