### PR TITLE
Use https://signet.ordinals.com as default signet publish URL

### DIFF
--- a/src/chain.rs
+++ b/src/chain.rs
@@ -21,6 +21,14 @@ impl Chain {
     }
   }
 
+  pub(crate) fn default_publish_url(self) -> Option<Url> {
+    match self {
+      Self::Mainnet => Some("https://ordinals.com".parse().unwrap()),
+      Self::Signet => Some("https://signet.ordinals.com".parse().unwrap()),
+      Self::Regtest | Self::Testnet => None,
+    }
+  }
+
   pub(crate) fn default_rpc_port(self) -> u16 {
     match self {
       Self::Mainnet => 8332,
@@ -70,5 +78,24 @@ impl Display for Chain {
         Self::Testnet => "testnet",
       }
     )
+  }
+}
+
+#[cfg(test)]
+mod tests {
+  use super::*;
+
+  #[test]
+  fn default_publish_url() {
+    assert_eq!(
+      Chain::Mainnet.default_publish_url(),
+      Some("https://ordinals.com".parse().unwrap())
+    );
+    assert_eq!(
+      Chain::Signet.default_publish_url(),
+      Some("https://signet.ordinals.com".parse().unwrap())
+    );
+    assert_eq!(Chain::Testnet.default_publish_url(), None,);
+    assert_eq!(Chain::Regtest.default_publish_url(), None,);
   }
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -32,6 +32,7 @@ use {
   clap::Parser,
   derive_more::{Display, FromStr},
   regex::Regex,
+  reqwest::Url,
   serde::{Deserialize, Serialize},
   std::{
     collections::VecDeque,

--- a/src/subcommand/rune/publish.rs
+++ b/src/subcommand/rune/publish.rs
@@ -8,10 +8,9 @@ pub(crate) struct Publish {
   ordinal: Ordinal,
   #[clap(
     long,
-    default_value = "https://ordinals.com/",
-    help = "Publish rune to <PUBLISH_URL>."
+    help = "Publish rune to <PUBLISH_URL>. [mainnet default: https://ordinals.com, signet default: https://signet.ordinals.com]"
   )]
-  publish_url: Url,
+  publish_url: Option<Url>,
 }
 
 impl Publish {
@@ -26,7 +25,15 @@ impl Publish {
 
     let json = serde_json::to_string(&rune)?;
 
-    let url = self.publish_url.join("rune")?;
+    let url = self
+      .publish_url
+      .or_else(|| match options.chain {
+        Chain::Mainnet => Some("https://ordinals.com".parse().unwrap()),
+        Chain::Signet => Some("https://signet.ordinals.com".parse().unwrap()),
+        Chain::Regtest | Chain::Testnet => None,
+      })
+      .ok_or_else(|| anyhow!("No default <PUBLISH_URL> for {}", options.chain))?
+      .join("rune")?;
 
     let response = reqwest::blocking::Client::new()
       .put(url.clone())

--- a/src/subcommand/rune/publish.rs
+++ b/src/subcommand/rune/publish.rs
@@ -1,4 +1,4 @@
-use {super::*, reqwest::Url};
+use super::*;
 
 #[derive(Debug, Parser)]
 pub(crate) struct Publish {
@@ -27,11 +27,7 @@ impl Publish {
 
     let url = self
       .publish_url
-      .or_else(|| match options.chain {
-        Chain::Mainnet => Some("https://ordinals.com".parse().unwrap()),
-        Chain::Signet => Some("https://signet.ordinals.com".parse().unwrap()),
-        Chain::Regtest | Chain::Testnet => None,
-      })
+      .or_else(|| options.chain.default_publish_url())
       .ok_or_else(|| anyhow!("No default <PUBLISH_URL> for {}", options.chain))?
       .join("rune")?;
 


### PR DESCRIPTION
Previously, we were using https://ordinals.com as the default publish URL, regardless of `ord`'s current network.