### PR TITLE
Append network to data dir

### DIFF
--- a/src/index.rs
+++ b/src/index.rs
@@ -106,7 +106,13 @@ impl Index {
     let client = Client::new(&rpc_url, Auth::CookieFile(cookie_file))
       .context("Failed to connect to RPC URL")?;
 
-    let database_path = options.data_dir()?.join("index.redb");
+    let data_dir = options.data_dir()?;
+
+    if let Err(err) = fs::create_dir_all(&data_dir) {
+      bail!("Failed to create data dir `{}`: {err}", data_dir.display());
+    }
+
+    let database_path = data_dir.join("index.redb");
 
     let database = match unsafe { redb::Database::open(&database_path) } {
       Ok(database) => database,

--- a/src/options.rs
+++ b/src/options.rs
@@ -221,9 +221,8 @@ mod tests {
 
   #[test]
   fn mainnet_cookie_file_path() {
-    let arguments = Arguments::try_parse_from(&["ord", "index"]).unwrap();
-
-    let cookie_file = arguments
+    let cookie_file = Arguments::try_parse_from(&["ord", "index"])
+      .unwrap()
       .options
       .cookie_file()
       .unwrap()
@@ -273,18 +272,27 @@ mod tests {
 
   #[test]
   fn mainnet_data_dir() {
-    let arguments = Arguments::try_parse_from(&["ord", "index"]).unwrap();
-
-    let data_dir = arguments.options.data_dir().unwrap().display().to_string();
-
-    assert!(data_dir.ends_with("/ord"));
+    let data_dir = Arguments::try_parse_from(&["ord", "index"])
+      .unwrap()
+      .options
+      .data_dir()
+      .unwrap()
+      .display()
+      .to_string();
+    assert!(data_dir.ends_with("/ord"), "{data_dir}");
   }
 
   #[test]
   fn othernet_data_dir() {
-    let arguments = Arguments::try_parse_from(&["ord", "--chain=signet", "index"]).unwrap();
-
-    let data_dir = arguments.options.data_dir().unwrap().display().to_string();
+    let data_dir = Arguments::try_parse_from(&["ord", "--chain=signet", "index"])
+      .unwrap()
+      .options
+      .data_dir()
+      .unwrap()
+      .display()
+      .to_string();
+    assert!(data_dir.ends_with("/ord/signet"), "{data_dir}");
+  }
 
   #[test]
   fn network_is_joined_with_data_dir() {

--- a/src/options.rs
+++ b/src/options.rs
@@ -62,21 +62,14 @@ impl Options {
   }
 
   pub(crate) fn data_dir(&self) -> Result<PathBuf> {
-    if let Some(data_dir) = &self.data_dir {
-      return Ok(data_dir.clone());
-    }
+    let base = match &self.data_dir {
+      Some(base) => base.clone(),
+      None => dirs::data_dir()
+        .ok_or_else(|| anyhow!("Failed to retrieve data dir"))?
+        .join("ord"),
+    };
 
-    let path = dirs::data_dir()
-      .ok_or_else(|| anyhow!("Failed to retrieve data dir"))?
-      .join("ord");
-
-    let path = self.chain.join_with_data_dir(&path);
-
-    if let Err(err) = fs::create_dir_all(&path) {
-      bail!("Failed to create data dir `{}`: {err}", path.display());
-    }
-
-    Ok(path)
+    Ok(self.chain.join_with_data_dir(&base))
   }
 
   pub(crate) fn bitcoin_rpc_client(&self) -> Result<Client> {

--- a/src/options.rs
+++ b/src/options.rs
@@ -286,7 +286,17 @@ mod tests {
 
     let data_dir = arguments.options.data_dir().unwrap().display().to_string();
 
-    assert!(data_dir.ends_with("/ord/signet"));
+  #[test]
+  fn network_is_joined_with_data_dir() {
+    let data_dir =
+      Arguments::try_parse_from(&["ord", "--chain=signet", "--data-dir", "foo", "index"])
+        .unwrap()
+        .options
+        .data_dir()
+        .unwrap()
+        .display()
+        .to_string();
+    assert!(data_dir.ends_with("foo/signet"), "{data_dir}");
   }
 
   #[test]

--- a/src/subcommand/server.rs
+++ b/src/subcommand/server.rs
@@ -213,11 +213,20 @@ impl Server {
   }
 
   fn acme_cache(acme_cache: Option<&PathBuf>, options: &Options) -> Result<PathBuf> {
-    if let Some(acme_cache) = acme_cache {
-      Ok(acme_cache.clone())
+    let acme_cache = if let Some(acme_cache) = acme_cache {
+      acme_cache.clone()
     } else {
-      Ok(options.data_dir()?.join("acme-cache"))
+      options.data_dir()?.join("acme-cache")
+    };
+
+    if let Err(err) = fs::create_dir_all(&acme_cache) {
+      bail!(
+        "Failed to create acme cache dir `{}`: {err}",
+        acme_cache.display()
+      );
     }
+
+    Ok(acme_cache)
   }
 
   fn acme_domains(acme_domain: &Vec<String>) -> Result<Vec<String>> {


### PR DESCRIPTION
This is what bitcoin core does, and allows running instances of `ord` on different networks with the same argument to `--data-dir`.