### PR TITLE
List prime ordinals on transaction page

### DIFF
--- a/src/index.rs
+++ b/src/index.rs
@@ -561,7 +561,7 @@ impl Index {
       outpoint_to_ordinal_ranges.insert(&encode_outpoint(outpoint), &ordinals)?;
     }
 
-    txid_to_prime_ordinals.insert(&txid.as_inner(), &prime_ordinals)?;
+    txid_to_prime_ordinals.insert(txid.as_inner(), &prime_ordinals)?;
 
     Ok(())
   }
@@ -595,7 +595,7 @@ impl Index {
         .database
         .begin_read()?
         .open_table(TXID_TO_PRIME_ORDINALS)?
-        .get(&txid.as_inner())?
+        .get(txid.as_inner())?
         .map(|prime_ordinals| {
           prime_ordinals
             .chunks(7)

--- a/src/index.rs
+++ b/src/index.rs
@@ -13,15 +13,16 @@ use {
 
 mod rtx;
 
-const HASH_TO_RUNE: TableDefinition<[u8; 32], str> = TableDefinition::new("HASH_TO_RUNE");
-const HEIGHT_TO_HASH: TableDefinition<u64, [u8; 32]> = TableDefinition::new("HEIGHT_TO_HASH");
-const ORDINAL_TO_SATPOINT: TableDefinition<u64, [u8; 44]> =
-  TableDefinition::new("ORDINAL_TO_SATPOINT");
+const HEIGHT_TO_BLOCK_HASH: TableDefinition<u64, [u8; 32]> =
+  TableDefinition::new("HEIGHT_TO_BLOCK_HASH");
 const ORDINAL_TO_RUNE_HASHES: MultimapTableDefinition<u64, [u8; 32]> =
   MultimapTableDefinition::new("ORDINAL_TO_RUNE_HASHES");
+const ORDINAL_TO_SATPOINT: TableDefinition<u64, [u8; 44]> =
+  TableDefinition::new("ORDINAL_TO_SATPOINT");
 const OUTPOINT_TO_ORDINAL_RANGES: TableDefinition<[u8; 36], [u8]> =
   TableDefinition::new("OUTPOINT_TO_ORDINAL_RANGES");
-const STATISTICS: TableDefinition<u64, u64> = TableDefinition::new("STATISTICS");
+const RUNE_HASH_TO_RUNE: TableDefinition<[u8; 32], str> = TableDefinition::new("RUNE_HASH_TO_RUNE");
+const STATISTIC_TO_COUNT: TableDefinition<u64, u64> = TableDefinition::new("STATISTIC_TO_COUNT");
 
 fn encode_outpoint(outpoint: OutPoint) -> [u8; 36] {
   let mut array = [0; 36];
@@ -139,11 +140,11 @@ impl Index {
     };
 
     tx.open_multimap_table(ORDINAL_TO_RUNE_HASHES)?;
-    tx.open_table(HASH_TO_RUNE)?;
-    tx.open_table(HEIGHT_TO_HASH)?;
+    tx.open_table(RUNE_HASH_TO_RUNE)?;
+    tx.open_table(HEIGHT_TO_BLOCK_HASH)?;
     tx.open_table(ORDINAL_TO_SATPOINT)?;
     tx.open_table(OUTPOINT_TO_ORDINAL_RANGES)?;
-    tx.open_table(STATISTICS)?;
+    tx.open_table(STATISTIC_TO_COUNT)?;
 
     tx.commit()?;
 
@@ -165,7 +166,7 @@ impl Index {
     let wtx = self.begin_write()?;
 
     let blocks_indexed = wtx
-      .open_table(HEIGHT_TO_HASH)?
+      .open_table(HEIGHT_TO_BLOCK_HASH)?
       .range(0..)?
       .rev()
       .next()
@@ -175,7 +176,7 @@ impl Index {
     let utxos_indexed = wtx.open_table(OUTPOINT_TO_ORDINAL_RANGES)?.len()?;
 
     let outputs_traversed = wtx
-      .open_table(STATISTICS)?
+      .open_table(STATISTIC_TO_COUNT)?
       .get(&Statistic::OutputsTraversed.into())?
       .unwrap_or(0);
 
@@ -217,7 +218,7 @@ impl Index {
     let mut wtx = self.begin_write()?;
 
     let height = wtx
-      .open_table(HEIGHT_TO_HASH)?
+      .open_table(HEIGHT_TO_BLOCK_HASH)?
       .range(0..)?
       .rev()
       .next()
@@ -263,7 +264,7 @@ impl Index {
   }
 
   pub(crate) fn index_block(&self, wtx: &mut WriteTransaction, height: u64) -> Result<bool> {
-    let mut height_to_hash = wtx.open_table(HEIGHT_TO_HASH)?;
+    let mut height_to_block_hash = wtx.open_table(HEIGHT_TO_BLOCK_HASH)?;
     let mut ordinal_to_satpoint = wtx.open_table(ORDINAL_TO_SATPOINT)?;
     let mut outpoint_to_ordinal_ranges = wtx.open_table(OUTPOINT_TO_ORDINAL_RANGES)?;
 
@@ -309,7 +310,7 @@ impl Index {
     );
 
     if let Some(prev_height) = height.checked_sub(1) {
-      let prev_hash = height_to_hash.get(&prev_height)?.unwrap();
+      let prev_hash = height_to_block_hash.get(&prev_height)?.unwrap();
 
       if prev_hash != block.header.prev_blockhash.as_ref() {
         self.reorged.store(true, Ordering::Relaxed);
@@ -369,13 +370,14 @@ impl Index {
         tx,
         &mut ordinal_to_satpoint,
         &mut outpoint_to_ordinal_ranges,
+        &mut txid_to_prime_ordinals,
         &mut coinbase_inputs,
         &mut ordinal_ranges_written,
         &mut outputs_in_block,
       )?;
     }
 
-    height_to_hash.insert(&height, &block.block_hash().as_hash().into_inner())?;
+    height_to_block_hash.insert(&height, &block.block_hash().as_hash().into_inner())?;
 
     Self::increment_statistic(wtx, Statistic::OutputsTraversed, outputs_in_block)?;
 
@@ -402,10 +404,10 @@ impl Index {
   }
 
   fn increment_statistic(wtx: &WriteTransaction, statistic: Statistic, n: u64) -> Result {
-    let mut statistics = wtx.open_table(STATISTICS)?;
-    statistics.insert(
+    let mut statistic_to_count = wtx.open_table(STATISTIC_TO_COUNT)?;
+    statistic_to_count.insert(
       &statistic.into(),
-      &(statistics.get(&(statistic.into()))?.unwrap_or(0) + n),
+      &(statistic_to_count.get(&(statistic.into()))?.unwrap_or(0) + n),
     )?;
     Ok(())
   }
@@ -416,7 +418,7 @@ impl Index {
       self
         .database
         .begin_read()?
-        .open_table(STATISTICS)?
+        .open_table(STATISTIC_TO_COUNT)?
         .get(&(statistic.into()))?
         .unwrap_or(0),
     )
@@ -433,9 +435,9 @@ impl Index {
 
     let height = rtx.height()?;
 
-    let height_to_hash = rtx.0.open_table(HEIGHT_TO_HASH)?;
+    let height_to_block_hash = rtx.0.open_table(HEIGHT_TO_BLOCK_HASH)?;
 
-    let mut cursor = height_to_hash
+    let mut cursor = height_to_block_hash
       .range(height.saturating_sub(take.saturating_sub(1))..=height)?
       .rev();
 
@@ -591,7 +593,7 @@ impl Index {
       self
         .database
         .begin_read()?
-        .open_table(HASH_TO_RUNE)?
+        .open_table(RUNE_HASH_TO_RUNE)?
         .get(hash.as_inner())?
         .map(serde_json::from_str)
         .transpose()?,
@@ -604,7 +606,7 @@ impl Index {
     let wtx = self.begin_write()?;
 
     let created = wtx
-      .open_table(HASH_TO_RUNE)?
+      .open_table(RUNE_HASH_TO_RUNE)?
       .insert(hash.as_inner(), &json)?
       .is_none();
 
@@ -688,7 +690,7 @@ impl Index {
         let tx = self.database.begin_read()?;
 
         let current = tx
-          .open_table(HEIGHT_TO_HASH)?
+          .open_table(HEIGHT_TO_BLOCK_HASH)?
           .range(0..)?
           .rev()
           .next()

--- a/src/index/rtx.rs
+++ b/src/index/rtx.rs
@@ -7,7 +7,7 @@ impl Rtx<'_> {
     Ok(
       self
         .0
-        .open_table(HEIGHT_TO_HASH)?
+        .open_table(HEIGHT_TO_BLOCK_HASH)?
         .range(0..)?
         .rev()
         .next()

--- a/src/subcommand/server/templates/transaction.rs
+++ b/src/subcommand/server/templates/transaction.rs
@@ -4,13 +4,21 @@ use super::*;
 pub(crate) struct TransactionHtml {
   txid: Txid,
   transaction: Transaction,
+  prime_ordinals: Vec<Option<Ordinal>>,
   chain: Chain,
 }
 
 impl TransactionHtml {
-  pub(crate) fn new(transaction: Transaction, chain: Chain) -> Self {
+  pub(crate) fn new(
+    transaction: Transaction,
+    prime_ordinals: Vec<Option<Ordinal>>,
+    chain: Chain,
+  ) -> Self {
+    assert_eq!(transaction.output.len(), prime_ordinals.len());
+
     Self {
       txid: transaction.txid(),
+      prime_ordinals,
       transaction,
       chain,
     }
@@ -49,7 +57,7 @@ mod tests {
     };
 
     pretty_assert_eq!(
-      TransactionHtml::new(transaction, Chain::Mainnet).to_string(),
+      TransactionHtml::new(transaction, vec![Some(Ordinal(0)), Some(Ordinal(50 * COIN_VALUE))], Chain::Mainnet).to_string(),
       "
         <h1>Transaction <span class=monospace>9108ec7cbe9f1231dbf6374251b7267fb31cb23f36ed5a1d7344f5635b17dfe9</span></h1>
         <h2>2 Outputs</h2>
@@ -59,6 +67,7 @@ mod tests {
               9108ec7cbe9f1231dbf6374251b7267fb31cb23f36ed5a1d7344f5635b17dfe9:0
             </a>
             <dl>
+              <dt>prime ordinal</dt><dd><a href=/ordinal/0>0</a></dd>
               <dt>value</dt><dd>5000000000</dd>
               <dt>script pubkey</dt><dd class=data>OP_0</dd>
             </dl>
@@ -68,6 +77,7 @@ mod tests {
               9108ec7cbe9f1231dbf6374251b7267fb31cb23f36ed5a1d7344f5635b17dfe9:1
             </a>
             <dl>
+              <dt>prime ordinal</dt><dd><a href=/ordinal/5000000000>5000000000</a></dd>
               <dt>value</dt><dd>5000000000</dd>
               <dt>script pubkey</dt><dd class=data>OP_PUSHBYTES_1 01</dd>
             </dl>

--- a/templates/transaction.html
+++ b/templates/transaction.html
@@ -1,17 +1,20 @@
 <h1>Transaction <span class=monospace>{{self.txid}}</span></h1>
 <h2>{{"Output".tally(self.transaction.output.len())}}</h2>
 <ul class=monospace>
-%% for (vout, output) in self.transaction.output.iter().enumerate() {
+%% for (vout, (output, prime_ordinal)) in self.transaction.output.iter().zip(&self.prime_ordinals).enumerate() {
 %% let outpoint = OutPoint::new(self.txid, vout as u32);
   <li>
     <a href=/output/{{outpoint}} class=monospace>
-      {{ outpoint }}
+      {{outpoint}}
     </a>
     <dl>
-      <dt>value</dt><dd>{{ output.value }}</dd>
-      <dt>script pubkey</dt><dd class=data>{{ output.script_pubkey.asm() }}</dd>
+%% if let Some(prime_ordinal) = prime_ordinal {
+      <dt>prime ordinal</dt><dd><a href=/ordinal/{{prime_ordinal}}>{{prime_ordinal}}</a></dd>
+%% }
+      <dt>value</dt><dd>{{output.value}}</dd>
+      <dt>script pubkey</dt><dd class=data>{{output.script_pubkey.asm()}}</dd>
 %% if let Ok(address) = self.chain.address_from_script(&output.script_pubkey) {
-      <dt>address</dt><dd class=monospace>{{ address }}</dd>
+      <dt>address</dt><dd class=monospace>{{address}}</dd>
 %% }
     </dl>
   </li>


### PR DESCRIPTION
This PR introduces the concept of a "prime ordinal" for a given output. The prime ordinal of an output is just the first ordinal in that output. This might be useful for a few reasons:

- We can consider the prime ordinal of an output that, when spent, reveals and thus inscribes a rune, as the issuer of that rune. This can be used for authentication, so that the creator of a well-known rune can publish more runes, and by seeing that the same prime rune was used for both, can be used to establish the authenticity of later runes.

- I originally tried and gave up on saving ordinal ranges for every historical output that has ever existed. We purge entries from the `OUTPOINT_TO_ORDINAL_RANGES` table when outpoints are spent, in order to keep the database size down. However, keeping track of the historical location of all primes might actually be tractable. We might be able to keep a mapping of all transactions ever made to the primes in the outputs, as well as a mapping of all primes to their current satpoint. This would then allow, for example, quickly looking up all runes issued by a given prime, the prime of a given inscribed rune, and a primes current address. (Also nice is that every uncommon or better ordinal is also a prime, since it was the prime in the coinbase transaction outputs.)

This adds a new large table to the database, so we'll need to make sure that this we can still sync within 48 hours on the ordinals.com box.