### PR TITLE
Use redb's two-phase write strategy in production

### DIFF
--- a/src/index.rs
+++ b/src/index.rs
@@ -124,7 +124,11 @@ impl Index {
       Ok(database) => database,
       Err(redb::Error::Io(error)) if error.kind() == io::ErrorKind::NotFound => unsafe {
         Database::builder()
-          .set_write_strategy(WriteStrategy::Checksum)
+          .set_write_strategy(if cfg!(test) {
+            WriteStrategy::Checksum
+          } else {
+            WriteStrategy::TwoPhase
+          })
           .create(&database_path, options.max_index_size().0)?
       },
       Err(error) => return Err(error.into()),


### PR DESCRIPTION
I benchmarked redb's two write strategies, checksum, which uses a checksum to recover the database in case of a crash, and two-phase, which guarantees that the header on disk does not need to be recovered in case of a crash, but which requires an additional fsync per commit.

Two-phase narrowly beat out checksum, completing in 27 hours vs 28 hours. This is likely because sync time is dominated by very large commits, where checksum calculation is more costly than an additional commit. @cberner Nothing too surprising here, although I thought you'd be interested anyways.

```
checksum:
  start:
    Oct 13 06:01:45 ordinals.com ord-dev[652816]: [2022-10-13T06:01:45Z INFO  ord::index] Block 0 at 2009-01-03 18:15:05 UTC with 1 transactions…
  end:
    Oct 14 10:12:01 ordinals.com ord-dev[652816]: [2022-10-14T10:12:01Z INFO  ord::index] Block 758607 at 2022-10-14 10:04:47 UTC with 2788 transactions…
  time:
    28 hours, 11 minutes
  tests:
    4.1s

two-phase:
  start:
    Oct 14 17:53:13 ordinals.com ord-dev[667585]: [2022-10-14T17:53:13Z INFO  ord::index] Block 0 at 2009-01-03 18:15:05 UTC with 1 transactions…
  end:
    Oct 15 20:56:32 ordinals.com ord-dev[667585]: [2022-10-15T20:56:32Z INFO  ord::index] Block 758607 at 2022-10-14 10:04:47 UTC with 2788 transactions…
  time:
    27 hours, 3 minutes
  tests:
    5.1s
```