### PR TITLE
Improve transaction builder checks

### DIFF
--- a/src/subcommand/wallet/transaction_builder.rs
+++ b/src/subcommand/wallet/transaction_builder.rs
@@ -143,8 +143,13 @@ impl TransactionBuilder {
       })
       .expect("invariant: ordinal is contained in utxo ranges");
 
-    assert!(
-      self.inputs.contains(outpoint.0),
+    assert_eq!(
+      transaction
+        .input
+        .iter()
+        .filter(|tx_in| tx_in.previous_output == *outpoint.0)
+        .count(),
+      1,
       "invariant: inputs spend ordinal"
     );
 

--- a/src/subcommand/wallet/transaction_builder.rs
+++ b/src/subcommand/wallet/transaction_builder.rs
@@ -118,9 +118,12 @@ impl TransactionBuilder {
           .iter()
           .any(|(start, end)| self.ordinal.0 >= *start && self.ordinal.0 < *end)
       })
-      .expect("Could not find ordinal in utxo ranges");
+      .expect("invariant: ordinal is contained in utxo ranges");
 
-    assert!(self.inputs.contains(outpoint.0));
+    assert!(
+      self.inputs.contains(outpoint.0),
+      "invariant: inputs spend ordinal"
+    );
 
     let ordinal_offset = self.calculate_ordinal_offset();
 
@@ -129,12 +132,15 @@ impl TransactionBuilder {
     for output in &self.outputs {
       output_end += output.1.to_sat();
       if output_end > ordinal_offset {
-        assert_eq!(output.0, self.recipient);
+        assert_eq!(
+          output.0, self.recipient,
+          "invariant: ordinal is sent to recipient"
+        );
         found = true;
         break;
       }
     }
-    assert!(found);
+    assert!(found, "invariant: ordinal is found in outputs");
 
     Ok(Transaction {
       version: 1,

--- a/src/subcommand/wallet/transaction_builder.rs
+++ b/src/subcommand/wallet/transaction_builder.rs
@@ -420,4 +420,98 @@ mod tests {
       Err(Error::ConsumedByFee(Ordinal(14900)))
     )
   }
+
+  #[test]
+  #[should_panic(expected = "invariant: ordinal is contained in utxo ranges")]
+  fn invariant_ordinal_is_contained_in_utxo_ranges() {
+    TransactionBuilder::new(
+      [(
+        "1111111111111111111111111111111111111111111111111111111111111111:1"
+          .parse()
+          .unwrap(),
+        vec![(0, 2), (3, 5)],
+      )]
+      .into_iter()
+      .collect(),
+      Ordinal(2),
+      "tb1q6en7qjxgw4ev8xwx94pzdry6a6ky7wlfeqzunz"
+        .parse()
+        .unwrap(),
+    )
+    .build()
+    .ok();
+  }
+
+  #[test]
+  #[should_panic(expected = "invariant: inputs spend ordinal")]
+  fn invariant_inputs_spend_ordinal() {
+    TransactionBuilder::new(
+      [(
+        "1111111111111111111111111111111111111111111111111111111111111111:1"
+          .parse()
+          .unwrap(),
+        vec![(0, 5)],
+      )]
+      .into_iter()
+      .collect(),
+      Ordinal(2),
+      "tb1q6en7qjxgw4ev8xwx94pzdry6a6ky7wlfeqzunz"
+        .parse()
+        .unwrap(),
+    )
+    .build()
+    .ok();
+  }
+
+  #[test]
+  #[should_panic(expected = "invariant: ordinal is sent to recipient")]
+  fn invariant_ordinal_is_sent_to_recipient() {
+    let mut builder = TransactionBuilder::new(
+      [(
+        "1111111111111111111111111111111111111111111111111111111111111111:1"
+          .parse()
+          .unwrap(),
+        vec![(0, 5)],
+      )]
+      .into_iter()
+      .collect(),
+      Ordinal(2),
+      "tb1q6en7qjxgw4ev8xwx94pzdry6a6ky7wlfeqzunz"
+        .parse()
+        .unwrap(),
+    )
+    .select_ordinal()
+    .unwrap();
+
+    builder.outputs[0].0 = "tb1qx4gf3ya0cxfcwydpq8vr2lhrysneuj5d7lqatw"
+      .parse()
+      .unwrap();
+
+    builder.build().ok();
+  }
+
+  #[test]
+  #[should_panic(expected = "invariant: ordinal is found in outputs")]
+  fn invariant_ordinal_is_found_in_outputs() {
+    let mut builder = TransactionBuilder::new(
+      [(
+        "1111111111111111111111111111111111111111111111111111111111111111:1"
+          .parse()
+          .unwrap(),
+        vec![(0, 5)],
+      )]
+      .into_iter()
+      .collect(),
+      Ordinal(2),
+      "tb1q6en7qjxgw4ev8xwx94pzdry6a6ky7wlfeqzunz"
+        .parse()
+        .unwrap(),
+    )
+    .select_ordinal()
+    .unwrap();
+
+    builder.outputs[0].1 = Amount::from_sat(0);
+
+    builder.build().ok();
+  }
 }


### PR DESCRIPTION
- Add should-panic checks to ensure they're operating correctly
- Add invariant messages to all expects and asserts
- Refactor build checks to operate on the built transaction, instead of the builder. This seems better, since if we mess up transaction construction somehow, but the builder is okay, this would catch that case