### PR TITLE
Add encoding declaration to clock SVG

### DIFF
--- a/src/subcommand/server/templates/clock.rs
+++ b/src/subcommand/server/templates/clock.rs
@@ -86,7 +86,8 @@ mod tests {
   fn clock_svg() {
     assert_regex_match!(
       ClockSvg::new(Height(6929999)).to_string(),
-      r##"<svg.*>.*
+      r##"<\?xml version="1.0" encoding="UTF-8"\?>
+<svg.*>.*
   <text.*>6929999</text>.*
   <line y2="-9" transform="rotate\(359.9999480519481\)"><title>Subsidy</title></line>.*
   <line y2="-13" stroke-width="0.6" transform="rotate\(359.9982857142857\)"><title>Epoch</title></line>.*

--- a/templates/clock.svg
+++ b/templates/clock.svg
@@ -1,3 +1,4 @@
+<?xml version="1.0" encoding="UTF-8"?>
 <svg viewBox="-20 -20 40 40" stroke-linecap="round" stroke="black" fill="white" xmlns="http://www.w3.org/2000/svg">
   <style>
     .epic:hover {


### PR DESCRIPTION
Apparently you're supposed to do this.