### PR TITLE
Ensure that send addressess are valid for current network

### DIFF
--- a/src/chain.rs
+++ b/src/chain.rs
@@ -12,7 +12,7 @@ pub(crate) enum Chain {
 }
 
 impl Chain {
-  fn network(self) -> bitcoin::Network {
+  pub(crate) fn network(self) -> bitcoin::Network {
     match self {
       Self::Mainnet => bitcoin::Network::Bitcoin,
       Self::Testnet => bitcoin::Network::Testnet,

--- a/src/subcommand/wallet/send.rs
+++ b/src/subcommand/wallet/send.rs
@@ -8,6 +8,14 @@ pub(crate) struct Send {
 
 impl Send {
   pub(crate) fn run(self, options: Options) -> Result {
+    if !self.address.is_valid_for_network(options.chain.network()) {
+      bail!(
+        "Address `{}` is not valid for {}",
+        self.address,
+        options.chain
+      );
+    }
+
     let client = options.bitcoin_rpc_client_mainnet_forbidden("ord wallet send")?;
 
     let index = Index::open(&options)?;

--- a/tests/wallet.rs
+++ b/tests/wallet.rs
@@ -53,9 +53,25 @@ fn send_not_allowed_on_mainnet() {
   let rpc_server = test_bitcoincore_rpc::spawn();
   rpc_server.mine_blocks(1)[0].txdata[0].txid();
 
+  CommandBuilder::new(
+    "wallet send 5000000000 bc1qzjeg3h996kw24zrg69nge97fw8jc4v7v7yznftzk06j3429t52vse9tkp9",
+  )
+  .rpc_server(&rpc_server)
+  .expected_stderr("error: `ord wallet send` is unstable and not yet supported on mainnet.\n")
+  .expected_exit_code(1)
+  .run();
+}
+
+#[test]
+fn send_addresses_must_be_valid_for_network() {
+  let rpc_server = test_bitcoincore_rpc::spawn();
+  rpc_server.mine_blocks(1)[0].txdata[0].txid();
+
   CommandBuilder::new("wallet send 5000000000 tb1qx4gf3ya0cxfcwydpq8vr2lhrysneuj5d7lqatw")
     .rpc_server(&rpc_server)
-    .expected_stderr("error: `ord wallet send` is unstable and not yet supported on mainnet.\n")
+    .expected_stderr(
+      "error: Address `tb1qx4gf3ya0cxfcwydpq8vr2lhrysneuj5d7lqatw` is not valid for mainnet\n",
+    )
     .expected_exit_code(1)
     .run();
 }


### PR DESCRIPTION
Addresses encode the network that they are valid for. Check this, so that it's not possible to send to, for example, a signet address on mainnet.