### PR TITLE
Make index faster by faster checking for uncommon or more rare ordinals

### DIFF
--- a/src/index.rs
+++ b/src/index.rs
@@ -526,7 +526,7 @@ impl Index {
           .pop_front()
           .ok_or_else(|| anyhow!("Insufficient inputs for transaction outputs"))?;
 
-        if Ordinal(range.0).is_uncommon_or_more_rare() {
+        if !Ordinal(range.0).is_common() {
           ordinal_to_satpoint.insert(
             &range.0,
             &encode_satpoint(SatPoint {

--- a/src/index.rs
+++ b/src/index.rs
@@ -526,7 +526,7 @@ impl Index {
           .pop_front()
           .ok_or_else(|| anyhow!("Insufficient inputs for transaction outputs"))?;
 
-        if Ordinal(range.0).rarity() > Rarity::Common {
+        if Ordinal(range.0).is_uncommon_or_more_rare() {
           ordinal_to_satpoint.insert(
             &range.0,
             &encode_satpoint(SatPoint {

--- a/src/ordinal.rs
+++ b/src/ordinal.rs
@@ -52,10 +52,12 @@ impl Ordinal {
     self.into()
   }
 
+  /// `Ordinal::rarity` is expensive and is called frequently when indexing.
+  /// Ordinal::is_common only checks if self is `Rarity::Common` but is
+  /// much faster.
   pub(crate) fn is_common(self) -> bool {
-    let e = self.epoch();
-    let third_inlined = (self.0 - e.starting_ordinal().0) % e.subsidy();
-    third_inlined != 0
+    let epoch = self.epoch();
+    (self.0 - epoch.starting_ordinal().0) % epoch.subsidy() != 0
   }
 
   pub(crate) fn name(self) -> String {

--- a/src/ordinal.rs
+++ b/src/ordinal.rs
@@ -52,10 +52,10 @@ impl Ordinal {
     self.into()
   }
 
-  pub(crate) fn is_uncommon_or_more_rare(self) -> bool {
+  pub(crate) fn is_common(self) -> bool {
     let e = self.epoch();
     let third_inlined = (self.0 - e.starting_ordinal().0) % e.subsidy();
-    third_inlined == 0
+    third_inlined != 0
   }
 
   pub(crate) fn name(self) -> String {
@@ -602,5 +602,24 @@ mod tests {
       case(Ordinal::LAST.n() - n);
       case(Ordinal::LAST.n() / (n + 1));
     }
+  }
+
+  #[test]
+  fn is_common() {
+    fn case(n: u64) {
+      assert_eq!(
+        Ordinal(n).is_common(),
+        Ordinal(n).rarity() == Rarity::Common
+      );
+    }
+
+    case(0);
+    case(1);
+    case(50 * COIN_VALUE - 1);
+    case(50 * COIN_VALUE);
+    case(50 * COIN_VALUE + 1);
+    case(2067187500000000 - 1);
+    case(2067187500000000);
+    case(2067187500000000 + 1);
   }
 }

--- a/src/ordinal.rs
+++ b/src/ordinal.rs
@@ -52,6 +52,12 @@ impl Ordinal {
     self.into()
   }
 
+  pub(crate) fn is_uncommon_or_more_rare(self) -> bool {
+    let e = self.epoch();
+    let third_inlined = (self.0 - e.starting_ordinal().0) % e.subsidy();
+    third_inlined == 0
+  }
+
   pub(crate) fn name(self) -> String {
     let mut x = Self::SUPPLY - self.0;
     let mut name = String::new();


### PR DESCRIPTION
Working on #371 starting with a trivial improvement:

Replace check for uncommon or better rarity by specialized, more efficient method. This line in index_transaction accounted 70% of the time in index_transaction, so it's worth the more verbose, less general method.

There's more potential here, as self.epoch() can likely be sped up significantly - the binary search takes an inordinate amount of time still.