### PR TITLE
Show difficulty target on block page

### DIFF
--- a/src/index.rs
+++ b/src/index.rs
@@ -309,7 +309,15 @@ impl Index {
     Ok(result)
   }
 
-  pub(crate) fn block(&self, height: u64) -> Result<Option<Block>> {
+  pub(crate) fn block_header(&self, hash: BlockHash) -> Result<Option<BlockHeader>> {
+    self.client.get_block_header(&hash).into_option()
+  }
+
+  pub(crate) fn block_header_info(&self, hash: BlockHash) -> Result<Option<GetBlockHeaderResult>> {
+    self.client.get_block_header_info(&hash).into_option()
+  }
+
+  pub(crate) fn get_block_by_height(&self, height: u64) -> Result<Option<Block>> {
     Ok(
       self
         .client
@@ -320,15 +328,7 @@ impl Index {
     )
   }
 
-  pub(crate) fn block_header(&self, hash: BlockHash) -> Result<Option<BlockHeader>> {
-    self.client.get_block_header(&hash).into_option()
-  }
-
-  pub(crate) fn block_header_info(&self, hash: BlockHash) -> Result<Option<GetBlockHeaderResult>> {
-    self.client.get_block_header_info(&hash).into_option()
-  }
-
-  pub(crate) fn block_with_hash(&self, hash: BlockHash) -> Result<Option<Block>> {
+  pub(crate) fn get_block_by_hash(&self, hash: BlockHash) -> Result<Option<Block>> {
     self.client.get_block(&hash).into_option()
   }
 
@@ -429,7 +429,7 @@ impl Index {
   pub(crate) fn blocktime(&self, height: Height) -> Result<Blocktime> {
     let height = height.n();
 
-    match self.block(height)? {
+    match self.get_block_by_height(height)? {
       Some(block) => Ok(Blocktime::Confirmed(block.header.time.into())),
       None => {
         let tx = self.database.begin_read()?;

--- a/src/subcommand/server.rs
+++ b/src/subcommand/server.rs
@@ -419,7 +419,16 @@ impl Server {
       }
     };
 
-    Ok(BlockHtml::new(block, Height(height), index.height().unwrap()).page())
+    Ok(
+      BlockHtml::new(
+        block,
+        Height(height),
+        index
+          .height()
+          .map_err(|err| ServerError::Internal(anyhow!("failed to get index height: {err}")))?,
+      )
+      .page(),
+    )
   }
 
   async fn transaction(

--- a/src/subcommand/server.rs
+++ b/src/subcommand/server.rs
@@ -1157,7 +1157,7 @@ mod tests {
   }
 
   #[test]
-  fn block() {
+  fn block_by_hash() {
     let test_server = TestServer::new();
 
     test_server.bitcoin_rpc_server.mine_blocks(1);
@@ -1188,6 +1188,26 @@ next
   <li><a href=/tx/[[:xdigit:]]{64}>[[:xdigit:]]{64}</a></li>
   <li><a href=/tx/[[:xdigit:]]{64}>[[:xdigit:]]{64}</a></li>
 </ul>.*",
+    );
+  }
+
+  #[test]
+  fn block_by_height() {
+    let test_server = TestServer::new();
+
+    test_server.assert_response_regex(
+      &format!("/block/0"),
+      StatusCode::OK,
+      ".*<h1>Block 0</h1>
+<dl>
+  <dt>hash</dt><dd class=monospace>[[:xdigit:]]{64}</dd>
+  <dt>target</dt><dd class=monospace>[[:xdigit:]]{64}</dd>
+  <dt>timestamp</dt><dd>1231006505</dd>
+  <dt>size</dt><dd>285</dd>
+  <dt>weight</dt><dd>1140</dd>
+</dl>
+prev
+next.*",
     );
   }
 

--- a/src/subcommand/server.rs
+++ b/src/subcommand/server.rs
@@ -43,9 +43,9 @@ impl FromStr for BlockQuery {
 
   fn from_str(s: &str) -> Result<Self, Self::Err> {
     Ok(if s.len() == 64 {
-      BlockQuery::Hash(s.parse().unwrap())
+      BlockQuery::Hash(s.parse()?)
     } else {
-      BlockQuery::Height(s.parse().unwrap())
+      BlockQuery::Height(s.parse()?)
     })
   }
 }

--- a/src/subcommand/server.rs
+++ b/src/subcommand/server.rs
@@ -1172,14 +1172,17 @@ mod tests {
     test_server.assert_response_regex(
       &format!("/block/{block_hash}"),
       StatusCode::OK,
-      ".*<h1>Block <span class=monospace>[[:xdigit:]]{64}</span></h1>
+      ".*<h1>Block 2</h1>
 <dl>
-  <dt>height</dt><dd>2</dd>
+  <dt>hash</dt><dd class=monospace>[[:xdigit:]]{64}</dd>
+  <dt>target</dt><dd class=monospace>[[:xdigit:]]{64}</dd>
   <dt>timestamp</dt><dd>0</dd>
   <dt>size</dt><dd>203</dd>
   <dt>weight</dt><dd>812</dd>
-  <dt>prev blockhash</dt><dd><a href=/block/659f9b67fbc0b5cba0ef6ebc0aea322e1c246e29e43210bd581f5f3bd36d17bf class=monospace>659f9b67fbc0b5cba0ef6ebc0aea322e1c246e29e43210bd581f5f3bd36d17bf</a></dd>
+  <dt>previous blockhash</dt><dd><a href=/block/659f9b67fbc0b5cba0ef6ebc0aea322e1c246e29e43210bd581f5f3bd36d17bf class=monospace>659f9b67fbc0b5cba0ef6ebc0aea322e1c246e29e43210bd581f5f3bd36d17bf</a></dd>
 </dl>
+<a href=/block/1>prev</a>
+next
 <h2>2 Transactions</h2>
 <ul class=monospace>
   <li><a href=/tx/[[:xdigit:]]{64}>[[:xdigit:]]{64}</a></li>

--- a/src/subcommand/server.rs
+++ b/src/subcommand/server.rs
@@ -1205,7 +1205,7 @@ next
     let test_server = TestServer::new();
 
     test_server.assert_response_regex(
-      &format!("/block/0"),
+      "/block/0",
       StatusCode::OK,
       ".*<h1>Block 0</h1>
 <dl>

--- a/src/subcommand/server/templates/block.rs
+++ b/src/subcommand/server/templates/block.rs
@@ -54,7 +54,6 @@ mod tests {
           <dt>timestamp</dt><dd>1231006505</dd>
           <dt>size</dt><dd>285</dd>
           <dt>weight</dt><dd>1140</dd>
-          <dt>previous blockhash</dt><dd><a href=/block/0000000000000000000000000000000000000000000000000000000000000000 class=monospace>0000000000000000000000000000000000000000000000000000000000000000</a></dd>
         </dl>
         prev
         next
@@ -80,7 +79,6 @@ mod tests {
           <dt>timestamp</dt><dd>1231006505</dd>
           <dt>size</dt><dd>285</dd>
           <dt>weight</dt><dd>1140</dd>
-          <dt>previous blockhash</dt><dd><a href=/block/0000000000000000000000000000000000000000000000000000000000000000 class=monospace>0000000000000000000000000000000000000000000000000000000000000000</a></dd>
         </dl>
         prev
         <a href=/block/1>next</a>

--- a/src/subcommand/server/templates/block.rs
+++ b/src/subcommand/server/templates/block.rs
@@ -11,19 +11,11 @@ pub(crate) struct BlockHtml {
 
 impl BlockHtml {
   pub(crate) fn new(block: Block, height: Height, best_height: Height) -> Self {
+    let mut target = block.header.target().to_be_bytes();
+    target.reverse();
     Self {
       hash: block.header.block_hash(),
-      target: BlockHash::from_inner(
-        block
-          .header
-          .target()
-          .to_be_bytes()
-          .into_iter()
-          .rev()
-          .collect::<Vec<u8>>()
-          .try_into()
-          .unwrap(),
-      ),
+      target: BlockHash::from_inner(target),
       block,
       height,
       best_height,

--- a/src/subcommand/server/templates/block.rs
+++ b/src/subcommand/server/templates/block.rs
@@ -44,17 +44,72 @@ mod tests {
   #[test]
   fn block_html() {
     pretty_assert_eq!(
-      BlockHtml::new( Chain::Mainnet.genesis_block() , Height(0))
+      BlockHtml::new( Chain::Mainnet.genesis_block() , Height(0), Height(0))
       .to_string(),
       "
-        <h1>Block <span class=monospace>000000000019d6689c085ae165831e934ff763ae46a2a6c172b3f1b60a8ce26f</span></h1>
+        <h1>Block 0</h1>
         <dl>
-          <dt>height</dt><dd>0</dd>
+          <dt>hash</dt><dd class=monospace>000000000019d6689c085ae165831e934ff763ae46a2a6c172b3f1b60a8ce26f</dd>
+          <dt>target</dt><dd class=monospace>00000000ffff0000000000000000000000000000000000000000000000000000</dd>
           <dt>timestamp</dt><dd>1231006505</dd>
           <dt>size</dt><dd>285</dd>
           <dt>weight</dt><dd>1140</dd>
-          <dt>prev blockhash</dt><dd><a href=/block/0000000000000000000000000000000000000000000000000000000000000000 class=monospace>0000000000000000000000000000000000000000000000000000000000000000</a></dd>
+          <dt>previous blockhash</dt><dd><a href=/block/0000000000000000000000000000000000000000000000000000000000000000 class=monospace>0000000000000000000000000000000000000000000000000000000000000000</a></dd>
         </dl>
+        prev
+        next
+        <h2>1 Transaction</h2>
+        <ul class=monospace>
+          <li><a href=/tx/4a5e1e4baab89f3a32518a88c31bc87f618f76673e2cc77ab2127b7afdeda33b>4a5e1e4baab89f3a32518a88c31bc87f618f76673e2cc77ab2127b7afdeda33b</a></li>
+        </ul>
+      "
+      .unindent()
+    );
+  }
+
+  #[test]
+  fn next_active_when_not_last() {
+    pretty_assert_eq!(
+      BlockHtml::new( Chain::Mainnet.genesis_block() , Height(0), Height(1))
+      .to_string(),
+      "
+        <h1>Block 0</h1>
+        <dl>
+          <dt>hash</dt><dd class=monospace>000000000019d6689c085ae165831e934ff763ae46a2a6c172b3f1b60a8ce26f</dd>
+          <dt>target</dt><dd class=monospace>00000000ffff0000000000000000000000000000000000000000000000000000</dd>
+          <dt>timestamp</dt><dd>1231006505</dd>
+          <dt>size</dt><dd>285</dd>
+          <dt>weight</dt><dd>1140</dd>
+          <dt>previous blockhash</dt><dd><a href=/block/0000000000000000000000000000000000000000000000000000000000000000 class=monospace>0000000000000000000000000000000000000000000000000000000000000000</a></dd>
+        </dl>
+        prev
+        <a href=/block/1>next</a>
+        <h2>1 Transaction</h2>
+        <ul class=monospace>
+          <li><a href=/tx/4a5e1e4baab89f3a32518a88c31bc87f618f76673e2cc77ab2127b7afdeda33b>4a5e1e4baab89f3a32518a88c31bc87f618f76673e2cc77ab2127b7afdeda33b</a></li>
+        </ul>
+      "
+      .unindent()
+    );
+  }
+
+  #[test]
+  fn prev_active_when_not_first() {
+    pretty_assert_eq!(
+      BlockHtml::new( Chain::Mainnet.genesis_block() , Height(1), Height(1))
+      .to_string(),
+      "
+        <h1>Block 1</h1>
+        <dl>
+          <dt>hash</dt><dd class=monospace>000000000019d6689c085ae165831e934ff763ae46a2a6c172b3f1b60a8ce26f</dd>
+          <dt>target</dt><dd class=monospace>00000000ffff0000000000000000000000000000000000000000000000000000</dd>
+          <dt>timestamp</dt><dd>1231006505</dd>
+          <dt>size</dt><dd>285</dd>
+          <dt>weight</dt><dd>1140</dd>
+          <dt>previous blockhash</dt><dd><a href=/block/0000000000000000000000000000000000000000000000000000000000000000 class=monospace>0000000000000000000000000000000000000000000000000000000000000000</a></dd>
+        </dl>
+        <a href=/block/0>prev</a>
+        next
         <h2>1 Transaction</h2>
         <ul class=monospace>
           <li><a href=/tx/4a5e1e4baab89f3a32518a88c31bc87f618f76673e2cc77ab2127b7afdeda33b>4a5e1e4baab89f3a32518a88c31bc87f618f76673e2cc77ab2127b7afdeda33b</a></li>

--- a/src/subcommand/server/templates/block.rs
+++ b/src/subcommand/server/templates/block.rs
@@ -3,16 +3,30 @@ use super::*;
 #[derive(Boilerplate)]
 pub(crate) struct BlockHtml {
   hash: BlockHash,
+  target: BlockHash,
+  best_height: Height,
   block: Block,
   height: Height,
 }
 
 impl BlockHtml {
-  pub(crate) fn new(block: Block, height: Height) -> Self {
+  pub(crate) fn new(block: Block, height: Height, best_height: Height) -> Self {
     Self {
       hash: block.header.block_hash(),
+      target: BlockHash::from_inner(
+        block
+          .header
+          .target()
+          .to_be_bytes()
+          .into_iter()
+          .rev()
+          .collect::<Vec<u8>>()
+          .try_into()
+          .unwrap(),
+      ),
       block,
       height,
+      best_height,
     }
   }
 }

--- a/src/subcommand/server/templates/ordinal.rs
+++ b/src/subcommand/server/templates/ordinal.rs
@@ -41,7 +41,7 @@ mod tests {
           <dt>rarity</dt><dd><span class=mythic>mythic</span></dd>
           <dt>time</dt><dd>1970-01-01 00:00:00</dd>
         </dl>
-        <a>prev</a>
+        prev
         <a href=/ordinal/1>next</a>
       "
       .unindent()
@@ -104,7 +104,7 @@ mod tests {
           <dt>time</dt><dd>1970-01-01 00:00:00</dd>
           <dt>inscription</dt><dd>HELLOWORLD</dd>
         </dl>
-        <a>prev</a>
+        prev
         <a href=/ordinal/1>next</a>
       "
       .unindent()
@@ -138,8 +138,39 @@ mod tests {
           <dt>time</dt><dd>1970-01-01 00:00:00</dd>
           <dt>inscription</dt><dd>&lt;script&gt;alert(&apos;HELLOWORLD&apos;);&lt;/script&gt;</dd>
         </dl>
-        <a>prev</a>
+        prev
         <a href=/ordinal/1>next</a>
+      "
+      .unindent()
+    );
+  }
+
+  #[test]
+  fn last_ordinal_next_link_is_disabled() {
+    pretty_assert_eq!(
+      OrdinalHtml {
+        ordinal: Ordinal::LAST,
+        blocktime: Blocktime::Confirmed(0),
+        inscription: None,
+      }
+      .to_string(),
+      "
+        <h1>Ordinal 2099999997689999</h1>
+        <dl>
+          <dt>decimal</dt><dd>6929999.0</dd>
+          <dt>degree</dt><dd>5°209999′1007″0‴</dd>
+          <dt>percentile</dt><dd>100%</dd>
+          <dt>name</dt><dd>a</dd>
+          <dt>cycle</dt><dd>5</dd>
+          <dt>epoch</dt><dd>32</dd>
+          <dt>period</dt><dd>3437</dd>
+          <dt>block</dt><dd>6929999</dd>
+          <dt>offset</dt><dd>0</dd>
+          <dt>rarity</dt><dd><span class=uncommon>uncommon</span></dd>
+          <dt>time</dt><dd>1970-01-01 00:00:00</dd>
+        </dl>
+        <a href=/ordinal/2099999997689998>prev</a>
+        next
       "
       .unindent()
     );

--- a/templates/block.html
+++ b/templates/block.html
@@ -5,7 +5,9 @@
   <dt>timestamp</dt><dd>{{self.block.header.time}}</dd>
   <dt>size</dt><dd>{{self.block.size()}}</dd>
   <dt>weight</dt><dd>{{self.block.weight()}}</dd>
+%% if self.height.0 > 0 {
   <dt>previous blockhash</dt><dd><a href=/block/{{self.block.header.prev_blockhash}} class=monospace>{{self.block.header.prev_blockhash}}</a></dd>
+%% }
 </dl>
 %% if let Some(prev_height) = self.height.n().checked_sub(1) {
 <a href=/block/{{prev_height}}>prev</a>

--- a/templates/block.html
+++ b/templates/block.html
@@ -1,11 +1,22 @@
-<h1>Block <span class=monospace>{{ self.hash }}</span></h1>
+<h1>Block {{ self.height }}</h1>
 <dl>
-  <dt>height</dt><dd>{{self.height}}</dd>
+  <dt>hash</dt><dd class=monospace>{{self.hash}}</dd>
+  <dt>target</dt><dd class=monospace>{{self.target}}</dd>
   <dt>timestamp</dt><dd>{{self.block.header.time}}</dd>
   <dt>size</dt><dd>{{self.block.size()}}</dd>
   <dt>weight</dt><dd>{{self.block.weight()}}</dd>
-  <dt>prev blockhash</dt><dd><a href=/block/{{self.block.header.prev_blockhash}} class=monospace>{{self.block.header.prev_blockhash}}</a></dd>
+  <dt>previous blockhash</dt><dd><a href=/block/{{self.block.header.prev_blockhash}} class=monospace>{{self.block.header.prev_blockhash}}</a></dd>
 </dl>
+%% if let Some(prev_height) = self.height.n().checked_sub(1) {
+<a href=/block/{{prev_height}}>prev</a>
+%% } else {
+prev
+%% }
+%% if self.height < self.best_height {
+<a href=/block/{{self.height + 1}}>next</a>
+%% } else {
+next
+%% }
 <h2>{{"Transaction".tally(self.block.txdata.len())}}</h2>
 <ul class=monospace>
 %% for tx in &self.block.txdata {

--- a/templates/ordinal.html
+++ b/templates/ordinal.html
@@ -18,10 +18,10 @@
 %% if self.ordinal.n() > 0 {
 <a href=/ordinal/{{self.ordinal.n() - 1}}>prev</a>
 %% } else {
-<a>prev</a>
+prev
 %% }
 %% if self.ordinal < Ordinal::LAST {
 <a href=/ordinal/{{self.ordinal.n() + 1}}>next</a>
 %% } else {
-<a>next</a>
+next
 %% }


### PR DESCRIPTION
Not sure about this since it's additional clutter, but really like it from a pedagogical point of view, since I think the idea of a difficulty target is most easily understood by seeing it along with block hashes.