### PR TITLE
Disable inscriptions on mainnet

### DIFF
--- a/src/index.rs
+++ b/src/index.rs
@@ -42,6 +42,7 @@ fn encode_satpoint(satpoint: SatPoint) -> [u8; 44] {
 
 pub(crate) struct Index {
   auth: Auth,
+  chain: Chain,
   client: Client,
   database: Database,
   database_path: PathBuf,
@@ -161,6 +162,7 @@ impl Index {
     Ok(Self {
       genesis_block_coinbase_txid: genesis_block_coinbase_transaction.txid(),
       auth,
+      chain: options.chain,
       client,
       database,
       database_path,

--- a/src/index/updater.rs
+++ b/src/index/updater.rs
@@ -2,11 +2,12 @@ use {super::*, std::sync::mpsc};
 
 pub struct Updater {
   cache: HashMap<[u8; 36], Vec<u8>>,
-  outputs_traversed: u64,
-  outputs_cached: u64,
-  ordinal_ranges_since_flush: u64,
-  outputs_inserted_since_flush: u64,
+  chain: Chain,
   height: u64,
+  ordinal_ranges_since_flush: u64,
+  outputs_cached: u64,
+  outputs_inserted_since_flush: u64,
+  outputs_traversed: u64,
 }
 
 impl Updater {
@@ -23,11 +24,12 @@ impl Updater {
 
     let mut updater = Self {
       cache: HashMap::new(),
-      outputs_traversed: 0,
+      chain: index.chain,
+      height,
+      ordinal_ranges_since_flush: 0,
       outputs_cached: 0,
       outputs_inserted_since_flush: 0,
-      ordinal_ranges_since_flush: 0,
-      height,
+      outputs_traversed: 0,
     };
 
     updater.update_index(index, wtx)
@@ -290,8 +292,11 @@ impl Updater {
     ordinal_ranges_written: &mut u64,
     outputs_traversed: &mut u64,
   ) -> Result {
-    if let Some((ordinal, inscription)) = Inscription::from_transaction(tx, input_ordinal_ranges) {
-      ordinal_to_inscription.insert(&ordinal.n(), &inscription.0)?;
+    if self.chain != Chain::Mainnet {
+      if let Some((ordinal, inscription)) = Inscription::from_transaction(tx, input_ordinal_ranges)
+      {
+        ordinal_to_inscription.insert(&ordinal.n(), &inscription.0)?;
+      }
     }
 
     for (vout, output) in tx.output.iter().enumerate() {


### PR DESCRIPTION
Parsing inscriptions might be responsible for a performance regression, per #798, making indexing the mainnet chain much slower. We don't want to enable inscriptions on mainnet anyways, so for now, just disable looking for them on mainnet.

There might be a performance issue here, but I'm confident that it can be fixed, so we can punt on it and deal with it later.