### PR TITLE
Record commit start block count and timestamp

### DIFF
--- a/src/index.rs
+++ b/src/index.rs
@@ -79,26 +79,26 @@ impl From<Statistic> for u64 {
 
 #[derive(Serialize)]
 pub(crate) struct Info {
-  blocks_indexed: u64,
-  branch_pages: usize,
-  fragmented_bytes: usize,
-  free_pages: usize,
-  index_file_size: u64,
-  leaf_pages: usize,
-  metadata_bytes: usize,
-  ordinal_ranges: u64,
-  outputs_traversed: u64,
-  page_size: usize,
-  stored_bytes: usize,
-  transactions: Vec<TransactionInfo>,
-  tree_height: usize,
-  utxos_indexed: usize,
+  pub(crate) blocks_indexed: u64,
+  pub(crate) branch_pages: usize,
+  pub(crate) fragmented_bytes: usize,
+  pub(crate) free_pages: usize,
+  pub(crate) index_file_size: u64,
+  pub(crate) leaf_pages: usize,
+  pub(crate) metadata_bytes: usize,
+  pub(crate) ordinal_ranges: u64,
+  pub(crate) outputs_traversed: u64,
+  pub(crate) page_size: usize,
+  pub(crate) stored_bytes: usize,
+  pub(crate) transactions: Vec<TransactionInfo>,
+  pub(crate) tree_height: usize,
+  pub(crate) utxos_indexed: usize,
 }
 
 #[derive(Serialize)]
 pub(crate) struct TransactionInfo {
-  starting_block_count: u64,
-  starting_timestamp: u64,
+  pub(crate) starting_block_count: u64,
+  pub(crate) starting_timestamp: u64,
 }
 
 trait BitcoinCoreRpcResultExt<T> {

--- a/src/index.rs
+++ b/src/index.rs
@@ -16,6 +16,8 @@ mod updater;
 
 const HEIGHT_TO_BLOCK_HASH: TableDefinition<u64, [u8; 32]> =
   TableDefinition::new("HEIGHT_TO_BLOCK_HASH");
+const WRITE_TRANSACTION_STARTING_BLOCK_COUNT_TO_TIMESTAMP: TableDefinition<u64, u64> =
+  TableDefinition::new("WRITE_TRANSACTION_START_BLOCK_COUNT_TO_TIMESTAMP");
 const ORDINAL_TO_INSCRIPTION_TXID: TableDefinition<u64, [u8; 32]> =
   TableDefinition::new("ORDINAL_TO_INSCRIPTION_TXID");
 const ORDINAL_TO_SATPOINT: TableDefinition<u64, [u8; 44]> =
@@ -156,6 +158,7 @@ impl Index {
     tx.open_table(OUTPOINT_TO_ORDINAL_RANGES)?;
     tx.open_table(STATISTIC_TO_COUNT)?;
     tx.open_table(TXID_TO_INSCRIPTION)?;
+    tx.open_table(WRITE_TRANSACTION_STARTING_BLOCK_COUNT_TO_TIMESTAMP)?;
 
     tx.commit()?;
 
@@ -179,41 +182,72 @@ impl Index {
   pub(crate) fn print_info(&self) -> Result {
     let wtx = self.begin_write()?;
 
-    let blocks_indexed = wtx
-      .open_table(HEIGHT_TO_BLOCK_HASH)?
-      .range(0..)?
-      .rev()
-      .next()
-      .map(|(height, _hash)| height + 1)
-      .unwrap_or(0);
-
-    let utxos_indexed = wtx.open_table(OUTPOINT_TO_ORDINAL_RANGES)?.len()?;
-
-    let ordinal_ranges = wtx
-      .open_table(STATISTIC_TO_COUNT)?
-      .get(&Statistic::OrdinalRanges.into())?
-      .unwrap_or(0);
-
-    let outputs_traversed = wtx
-      .open_table(STATISTIC_TO_COUNT)?
-      .get(&Statistic::OutputsTraversed.into())?
-      .unwrap_or(0);
-
     let stats = wtx.stats()?;
 
-    println!("blocks indexed\t{}", blocks_indexed);
-    println!("utxos indexed\t{}", utxos_indexed);
-    println!("outputs traversed\t{}", outputs_traversed);
-    println!("ordinal ranges\t{}", ordinal_ranges);
-    println!("tree height\t{}", stats.tree_height());
-    println!("free pages\t{}", stats.free_pages());
-    println!("stored\t{}", Bytes(stats.stored_bytes()));
-    println!("overhead\t{}", Bytes(stats.metadata_bytes()));
-    println!("fragmented\t{}", Bytes(stats.fragmented_bytes()));
-    println!(
-      "index size\t{}",
-      Bytes(std::fs::metadata(&self.database_path)?.len().try_into()?)
-    );
+    {
+      let statistic_to_count = wtx.open_table(STATISTIC_TO_COUNT)?;
+
+      #[derive(Serialize)]
+      struct Info {
+        blocks_indexed: u64,
+        branch_pages: usize,
+        fragmented_bytes: usize,
+        free_pages: usize,
+        index_file_size: u64,
+        leaf_pages: usize,
+        metadata_bytes: usize,
+        ordinal_ranges: u64,
+        outputs_traversed: u64,
+        page_size: usize,
+        stored_bytes: usize,
+        transactions: Vec<Transaction>,
+        tree_height: usize,
+        utxos_indexed: usize,
+      }
+
+      #[derive(Serialize)]
+      struct Transaction {
+        starting_block_count: u64,
+        starting_timestamp: u64,
+      }
+
+      serde_json::to_writer(
+        io::stdout(),
+        &Info {
+          blocks_indexed: wtx
+            .open_table(HEIGHT_TO_BLOCK_HASH)?
+            .range(0..)?
+            .rev()
+            .next()
+            .map(|(height, _hash)| height + 1)
+            .unwrap_or(0),
+          branch_pages: stats.branch_pages(),
+          fragmented_bytes: stats.fragmented_bytes(),
+          free_pages: stats.free_pages(),
+          index_file_size: fs::metadata(&self.database_path)?.len(),
+          leaf_pages: stats.leaf_pages(),
+          metadata_bytes: stats.metadata_bytes(),
+          ordinal_ranges: statistic_to_count
+            .get(&Statistic::OrdinalRanges.into())?
+            .unwrap_or(0),
+          outputs_traversed: statistic_to_count
+            .get(&Statistic::OutputsTraversed.into())?
+            .unwrap_or(0),
+          page_size: stats.page_size(),
+          stored_bytes: stats.stored_bytes(),
+          transactions: wtx
+            .open_table(WRITE_TRANSACTION_STARTING_BLOCK_COUNT_TO_TIMESTAMP)?
+            .range(0..)?
+            .map(|(starting_block_count, starting_timestamp)| Transaction {
+              starting_block_count,
+              starting_timestamp,
+            })
+            .collect(),
+          tree_height: stats.tree_height(),
+          utxos_indexed: wtx.open_table(OUTPOINT_TO_ORDINAL_RANGES)?.len()?,
+        },
+      )?;
+    }
 
     wtx.abort()?;
 

--- a/src/index.rs
+++ b/src/index.rs
@@ -16,7 +16,7 @@ mod updater;
 
 const HEIGHT_TO_BLOCK_HASH: TableDefinition<u64, [u8; 32]> =
   TableDefinition::new("HEIGHT_TO_BLOCK_HASH");
-const WRITE_TRANSACTION_STARTING_BLOCK_COUNT_TO_TIMESTAMP: TableDefinition<u64, u64> =
+const WRITE_TRANSACTION_STARTING_BLOCK_COUNT_TO_TIMESTAMP: TableDefinition<u64, u128> =
   TableDefinition::new("WRITE_TRANSACTION_START_BLOCK_COUNT_TO_TIMESTAMP");
 const ORDINAL_TO_INSCRIPTION_TXID: TableDefinition<u64, [u8; 32]> =
   TableDefinition::new("ORDINAL_TO_INSCRIPTION_TXID");
@@ -98,7 +98,7 @@ pub(crate) struct Info {
 #[derive(Serialize)]
 pub(crate) struct TransactionInfo {
   pub(crate) starting_block_count: u64,
-  pub(crate) starting_timestamp: u64,
+  pub(crate) starting_timestamp: u128,
 }
 
 trait BitcoinCoreRpcResultExt<T> {

--- a/src/index/updater.rs
+++ b/src/index/updater.rs
@@ -28,7 +28,7 @@ impl Updater {
         &height,
         &SystemTime::now()
           .duration_since(SystemTime::UNIX_EPOCH)
-          .map(|duration| duration.as_secs())
+          .map(|duration| duration.as_millis())
           .unwrap_or(0),
       )?;
 
@@ -108,7 +108,7 @@ impl Updater {
             &self.height,
             &SystemTime::now()
               .duration_since(SystemTime::UNIX_EPOCH)
-              .map(|duration| duration.as_secs())
+              .map(|duration| duration.as_millis())
               .unwrap_or(0),
           )?;
         uncomitted = 0;

--- a/src/main.rs
+++ b/src/main.rs
@@ -49,7 +49,7 @@ use {
       Arc, Mutex,
     },
     thread,
-    time::{Duration, Instant},
+    time::{Duration, Instant, SystemTime},
   },
   tokio::{runtime::Runtime, task},
   tower_http::cors::{Any, CorsLayer},

--- a/src/subcommand/info.rs
+++ b/src/subcommand/info.rs
@@ -3,6 +3,6 @@ use super::*;
 pub(crate) fn run(options: Options) -> Result {
   let index = Index::open(&options)?;
   index.update()?;
-  index.print_info()?;
+  serde_json::to_writer(io::stdout(), &index.info()?)?;
   Ok(())
 }

--- a/src/subcommand/server.rs
+++ b/src/subcommand/server.rs
@@ -1352,6 +1352,7 @@ next.*",
 
     server.bitcoin_rpc_server.mine_blocks(1);
 
+    thread::sleep(Duration::from_millis(10));
     server.index.update().unwrap();
 
     assert_eq!(
@@ -1366,6 +1367,9 @@ next.*",
     assert_eq!(info.transactions.len(), 2);
     assert_eq!(info.transactions[0].starting_block_count, 0);
     assert_eq!(info.transactions[1].starting_block_count, 1);
+    assert!(
+      info.transactions[1].starting_timestamp - info.transactions[0].starting_timestamp >= 10
+    );
   }
 
   #[test]

--- a/src/subcommand/server.rs
+++ b/src/subcommand/server.rs
@@ -1332,6 +1332,10 @@ next.*",
       1
     );
 
+    let info = server.index.info().unwrap();
+    assert_eq!(info.transactions.len(), 1);
+    assert_eq!(info.transactions[0].starting_block_count, 0);
+
     server.index.update().unwrap();
 
     assert_eq!(
@@ -1341,6 +1345,10 @@ next.*",
         .unwrap(),
       1
     );
+
+    let info = server.index.info().unwrap();
+    assert_eq!(info.transactions.len(), 1);
+    assert_eq!(info.transactions[0].starting_block_count, 0);
 
     server.bitcoin_rpc_server.mine_blocks(1);
 
@@ -1353,6 +1361,11 @@ next.*",
         .unwrap(),
       2
     );
+
+    let info = server.index.info().unwrap();
+    assert_eq!(info.transactions.len(), 2);
+    assert_eq!(info.transactions[0].starting_block_count, 0);
+    assert_eq!(info.transactions[1].starting_block_count, 1);
   }
 
   #[test]

--- a/tests/info.rs
+++ b/tests/info.rs
@@ -6,18 +6,7 @@ fn basic() {
   CommandBuilder::new("info")
     .rpc_server(&rpc_server)
     .stdout_regex(
-      "
-        blocks indexed\t1
-        utxos indexed\t1
-        outputs traversed\t1
-        ordinal ranges\t1
-        tree height\t\\d+
-        free pages\t\\d+
-        stored\t.*
-        overhead\t.*
-        fragmented\t.*
-      "
-      .unindent(),
+      r#"\{"blocks_indexed":1,"branch_pages":\d+,"fragmented_bytes":\d+,"free_pages":\d+,"index_file_size":\d+,"leaf_pages":\d+,"metadata_bytes":\d+,"ordinal_ranges":1,"outputs_traversed":1,"page_size":\d+,"stored_bytes":\d+,"transactions":\[\{"starting_block_count":0,"starting_timestamp":\d+\}\],"tree_height":\d+,"utxos_indexed":1\}"#
     )
     .run();
 }


### PR DESCRIPTION
Store this information in the database for each commit, so we don't need to look at log files to get this information, we can just look at the index.

Also convert `info` command output to JSON, so we can represent data with nested fields.