### PR TITLE
Add build-snapshots recipe

### DIFF
--- a/justfile
+++ b/justfile
@@ -120,11 +120,11 @@ build-snapshots:
   cargo build --release
   cp ./target/release/ord tmp/snapshots
   cd tmp/snapshots
-  ./ord --data-dir . --height-limit 0 index
-  mv index.redb 0.redb
   for start in {0..750000..50000}; do
     height_limit=$((start+50000))
-    cp -c $start.redb index.redb
+    if [[ -f $start.redb ]]; then
+      cp -c $start.redb index.redb
+    fi
     a=`date +%s`
     time ./ord --data-dir . --height-limit $height_limit index
     b=`date +%s`

--- a/justfile
+++ b/justfile
@@ -112,6 +112,26 @@ benchmark-revision rev:
   rsync -avz benchmark/checkout root@ordinals.com:benchmark/checkout
   ssh root@ordinals.com 'cd benchmark && ./checkout {{rev}}'
 
+build-snapshots:
+  #!/usr/bin/env bash
+  set -euxo pipefail
+  rm -rf tmp/snapshots
+  mkdir -p tmp/snapshots
+  cargo build --release
+  cp ./target/release/ord tmp/snapshots
+  cd tmp/snapshots
+  ./ord --data-dir . --height-limit 0 index
+  mv index.redb 0.redb
+  for start in {0..750000..50000}; do
+    height_limit=$((start+50000))
+    cp $start.redb index.redb
+    a=`date +%s`
+    time ./ord --data-dir . --height-limit $height_limit index
+    b=`date +%s`
+    mv index.redb $height_limit.redb
+    printf "$height_limit\t$((b - a))\n" >> time.txt
+  done
+
 serve-docs:
   mdbook serve docs --open
 

--- a/justfile
+++ b/justfile
@@ -124,7 +124,7 @@ build-snapshots:
   mv index.redb 0.redb
   for start in {0..750000..50000}; do
     height_limit=$((start+50000))
-    cp $start.redb index.redb
+    cp -c $start.redb index.redb
     a=`date +%s`
     time ./ord --data-dir . --height-limit $height_limit index
     b=`date +%s`


### PR DESCRIPTION
`just build-snapshots` will build snapshots of the index every 50,000 blocks in `tmp/snapshots` and record the time in seconds that each one took to build in `tmp/snapshots/time.txt`.