### PR TITLE
Only index ordinals if `--index-ordinals` is passed

### DIFF
--- a/deploy/ord-dev.service
+++ b/deploy/ord-dev.service
@@ -10,8 +10,9 @@ Environment=RUST_BACKTRACE=1
 Environment=RUST_LOG=info
 ExecStart=/usr/local/bin/ord-dev \
   --bitcoin-data-dir /var/lib/bitcoind \
-  --data-dir /var/lib/ord-dev \
   --chain ${CHAIN} \
+  --data-dir /var/lib/ord-dev \
+  --index-ordinals \
   server \
   --http-port 8080
 Group=ord

--- a/deploy/ord.service
+++ b/deploy/ord.service
@@ -12,6 +12,7 @@ ExecStart=/usr/local/bin/ord \
   --bitcoin-data-dir /var/lib/bitcoind \
   --data-dir /var/lib/ord \
   --chain ${CHAIN} \
+  --index-ordinals \
   server \
   --acme-contact mailto:casey@rodarmor.com \
   --http \

--- a/src/index.rs
+++ b/src/index.rs
@@ -299,11 +299,13 @@ impl Index {
 
   #[cfg(test)]
   pub(crate) fn statistic(&self, statistic: Statistic) -> Result<u64> {
-    if matches!(
-      statistic,
-      Statistic::OutputsTraversed | Statistic::OrdinalRanges
-    ) {
-      bail!("statistic requires the `--index-ordinal-ranges` flag");
+    if !self.index_ordinals
+      && matches!(
+        statistic,
+        Statistic::OutputsTraversed | Statistic::OrdinalRanges
+      )
+    {
+      bail!("statistic requires the `--index-ordinals` flag");
     }
 
     Ok(

--- a/src/index.rs
+++ b/src/index.rs
@@ -199,9 +199,9 @@ impl Index {
       database_path,
       genesis_block_coinbase_transaction,
       height_limit: options.height_limit,
+      index_ordinals: options.index_ordinals,
       reorged: AtomicBool::new(false),
       rpc_url,
-      index_ordinals: options.index_ordinals,
     })
   }
 

--- a/src/index.rs
+++ b/src/index.rs
@@ -55,7 +55,7 @@ pub(crate) struct Index {
   height_limit: Option<u64>,
   reorged: AtomicBool,
   rpc_url: String,
-  index_ordinal_ranges: bool,
+  index_ordinals: bool,
 }
 
 #[derive(Debug, PartialEq)]
@@ -201,7 +201,7 @@ impl Index {
       height_limit: options.height_limit,
       reorged: AtomicBool::new(false),
       rpc_url,
-      index_ordinal_ranges: false,
+      index_ordinals: options.index_ordinals,
     })
   }
 
@@ -341,7 +341,7 @@ impl Index {
   }
 
   pub(crate) fn rare_ordinal_satpoints(&self) -> Result<Vec<(Ordinal, SatPoint)>> {
-    if !self.index_ordinal_ranges {
+    if !self.index_ordinals {
       bail!("looking up rare ordinal statpoints requires the `--index-ordinal-ranges` flag");
     }
 
@@ -440,7 +440,7 @@ impl Index {
   }
 
   pub(crate) fn find(&self, ordinal: u64) -> Result<Option<SatPoint>> {
-    if !self.index_ordinal_ranges {
+    if !self.index_ordinals {
       bail!("find requires the `--index-ordinal-ranges` flag");
     }
 
@@ -482,7 +482,7 @@ impl Index {
   }
 
   pub(crate) fn list(&self, outpoint: OutPoint) -> Result<Option<List>> {
-    if !self.index_ordinal_ranges {
+    if !self.index_ordinals {
       bail!("list requires the `--index-ordinal-ranges` flag");
     }
 

--- a/src/index.rs
+++ b/src/index.rs
@@ -443,7 +443,7 @@ impl Index {
 
   pub(crate) fn find(&self, ordinal: u64) -> Result<Option<SatPoint>> {
     if !self.index_ordinals {
-      bail!("find requires the `--index-ordinal-ranges` flag");
+      bail!("find requires the `--index-ordinals` flag");
     }
 
     let rtx = self.begin_read()?;

--- a/src/index.rs
+++ b/src/index.rs
@@ -53,9 +53,9 @@ pub(crate) struct Index {
   genesis_block_coinbase_transaction: Transaction,
   genesis_block_coinbase_txid: Txid,
   height_limit: Option<u64>,
+  index_ordinals: bool,
   reorged: AtomicBool,
   rpc_url: String,
-  index_ordinals: bool,
 }
 
 #[derive(Debug, PartialEq)]

--- a/src/index.rs
+++ b/src/index.rs
@@ -547,10 +547,6 @@ mod tests {
   }
 
   impl Context {
-    fn new() -> Self {
-      Self::with_args("")
-    }
-
     fn with_args(args: &str) -> Self {
       let rpc_server = test_bitcoincore_rpc::spawn();
 
@@ -614,7 +610,7 @@ mod tests {
 
   #[test]
   fn list_first_coinbase_transaction() {
-    let context = Context::new();
+    let context = Context::with_args("--index-ordinals");
     assert_eq!(
       context
         .index
@@ -631,7 +627,7 @@ mod tests {
 
   #[test]
   fn list_second_coinbase_transaction() {
-    let context = Context::new();
+    let context = Context::with_args("--index-ordinals");
     let txid = context.rpc_server.mine_blocks(1)[0].txdata[0].txid();
     context.index.update().unwrap();
     assert_eq!(
@@ -642,7 +638,7 @@ mod tests {
 
   #[test]
   fn list_split_ranges_are_tracked_correctly() {
-    let context = Context::new();
+    let context = Context::with_args("--index-ordinals");
 
     context.rpc_server.mine_blocks(1);
     let split_coinbase_output = TransactionTemplate {
@@ -668,7 +664,7 @@ mod tests {
 
   #[test]
   fn list_merge_ranges_are_tracked_correctly() {
-    let context = Context::new();
+    let context = Context::with_args("--index-ordinals");
 
     context.rpc_server.mine_blocks(2);
     let merge_coinbase_outputs = TransactionTemplate {
@@ -692,7 +688,7 @@ mod tests {
 
   #[test]
   fn list_fee_paying_transaction_range() {
-    let context = Context::new();
+    let context = Context::with_args("--index-ordinals");
 
     context.rpc_server.mine_blocks(1);
     let fee_paying_tx = TransactionTemplate {
@@ -726,7 +722,7 @@ mod tests {
 
   #[test]
   fn list_two_fee_paying_transaction_range() {
-    let context = Context::new();
+    let context = Context::with_args("--index-ordinals");
 
     context.rpc_server.mine_blocks(2);
     let first_fee_paying_tx = TransactionTemplate {
@@ -761,7 +757,7 @@ mod tests {
 
   #[test]
   fn list_null_output() {
-    let context = Context::new();
+    let context = Context::with_args("--index-ordinals");
 
     context.rpc_server.mine_blocks(1);
     let no_value_output = TransactionTemplate {
@@ -781,7 +777,7 @@ mod tests {
 
   #[test]
   fn list_null_input() {
-    let context = Context::new();
+    let context = Context::with_args("--index-ordinals");
 
     context.rpc_server.mine_blocks(1);
     let no_value_output = TransactionTemplate {
@@ -809,7 +805,7 @@ mod tests {
 
   #[test]
   fn list_spent_output() {
-    let context = Context::new();
+    let context = Context::with_args("--index-ordinals");
     context.rpc_server.mine_blocks(1);
     context.rpc_server.broadcast_tx(TransactionTemplate {
       input_slots: &[(1, 0, 0)],
@@ -827,7 +823,7 @@ mod tests {
 
   #[test]
   fn list_unknown_output() {
-    let context = Context::new();
+    let context = Context::with_args("--index-ordinals");
 
     assert_eq!(
       context
@@ -844,7 +840,7 @@ mod tests {
 
   #[test]
   fn find_first_ordinal() {
-    let context = Context::new();
+    let context = Context::with_args("--index-ordinals");
     assert_eq!(
       context.index.find(0).unwrap().unwrap(),
       SatPoint {
@@ -858,7 +854,7 @@ mod tests {
 
   #[test]
   fn find_second_ordinal() {
-    let context = Context::new();
+    let context = Context::with_args("--index-ordinals");
     assert_eq!(
       context.index.find(1).unwrap().unwrap(),
       SatPoint {
@@ -872,7 +868,7 @@ mod tests {
 
   #[test]
   fn find_first_ordinal_of_second_block() {
-    let context = Context::new();
+    let context = Context::with_args("--index-ordinals");
     context.rpc_server.mine_blocks(1);
     context.index.update().unwrap();
     assert_eq!(
@@ -888,13 +884,13 @@ mod tests {
 
   #[test]
   fn find_unmined_ordinal() {
-    let context = Context::new();
+    let context = Context::with_args("--index-ordinals");
     assert_eq!(context.index.find(50 * COIN_VALUE).unwrap(), None);
   }
 
   #[test]
   fn find_first_satoshi_spent_in_second_block() {
-    let context = Context::new();
+    let context = Context::with_args("--index-ordinals");
     context.rpc_server.mine_blocks(1);
     let spend_txid = context.rpc_server.broadcast_tx(TransactionTemplate {
       input_slots: &[(1, 0, 0)],

--- a/src/index/updater.rs
+++ b/src/index/updater.rs
@@ -4,11 +4,11 @@ pub struct Updater {
   cache: HashMap<[u8; 36], Vec<u8>>,
   chain: Chain,
   height: u64,
+  index_ordinals: bool,
   ordinal_ranges_since_flush: u64,
   outputs_cached: u64,
   outputs_inserted_since_flush: u64,
   outputs_traversed: u64,
-  index_ordinals: bool,
 }
 
 impl Updater {

--- a/src/index/updater.rs
+++ b/src/index/updater.rs
@@ -8,7 +8,7 @@ pub struct Updater {
   outputs_cached: u64,
   outputs_inserted_since_flush: u64,
   outputs_traversed: u64,
-  index_ordinal_ranges: bool,
+  index_ordinals: bool,
 }
 
 impl Updater {
@@ -41,7 +41,7 @@ impl Updater {
       outputs_cached: 0,
       outputs_inserted_since_flush: 0,
       outputs_traversed: 0,
-      index_ordinal_ranges: false,
+      index_ordinals: index.index_ordinals,
     };
 
     updater.update_index(index, wtx)
@@ -234,7 +234,7 @@ impl Updater {
 
     let mut coinbase_inputs = VecDeque::new();
 
-    if self.index_ordinal_ranges {
+    if self.index_ordinals {
       let h = Height(self.height);
       if h.subsidy() > 0 {
         let start = h.starting_ordinal();
@@ -250,7 +250,7 @@ impl Updater {
 
       let mut input_ordinal_ranges = VecDeque::new();
 
-      if self.index_ordinal_ranges {
+      if self.index_ordinals {
         for input in &tx.input {
           let key = encode_outpoint(input.previous_output);
 
@@ -334,7 +334,7 @@ impl Updater {
       }
     }
 
-    if self.index_ordinal_ranges {
+    if self.index_ordinals {
       for (vout, output) in tx.output.iter().enumerate() {
         let outpoint = OutPoint {
           vout: vout as u32,

--- a/src/index/updater.rs
+++ b/src/index/updater.rs
@@ -37,11 +37,11 @@ impl Updater {
       cache: HashMap::new(),
       chain: index.chain,
       height,
+      index_ordinals: index.index_ordinals,
       ordinal_ranges_since_flush: 0,
       outputs_cached: 0,
       outputs_inserted_since_flush: 0,
       outputs_traversed: 0,
-      index_ordinals: index.index_ordinals,
     };
 
     updater.update_index(index, wtx)

--- a/src/options.rs
+++ b/src/options.rs
@@ -5,25 +5,25 @@ use {
 
 #[derive(Debug, Parser)]
 pub(crate) struct Options {
+  #[clap(long, help = "Load Bitcoin Core data dir from <BITCOIN_DATA_DIR>.")]
+  bitcoin_data_dir: Option<PathBuf>,
+  #[clap(long, arg_enum, default_value = "mainnet", help = "Index <CHAIN>.")]
+  pub(crate) chain: Chain,
+  #[clap(long, help = "Load Bitcoin Core RPC cookie file from <COOKIE_FILE>.")]
+  cookie_file: Option<PathBuf>,
+  #[clap(long, help = "Store index in <DATA_DIR>.")]
+  data_dir: Option<PathBuf>,
+  #[clap(long, help = "Limit index to <HEIGHT_LIMIT> blocks.")]
+  pub(crate) height_limit: Option<u64>,
+  #[clap(long, help = "Index ordinal ranges")]
+  pub(crate) index_ordinals: bool,
   #[clap(
     long,
     help = "Limit the ordinal index to <MAX_INDEX_SIZE> bytes. This cannot be changed later. [mainnet, testnet, and signet default: 1 TiB, regtest default: 10 MiB]"
   )]
   max_index_size: Option<Bytes>,
-  #[clap(long, help = "Load Bitcoin Core RPC cookie file from <COOKIE_FILE>.")]
-  cookie_file: Option<PathBuf>,
   #[clap(long, help = "Connect to Bitcoin Core RPC at <RPC_URL>.")]
   rpc_url: Option<String>,
-  #[clap(long, arg_enum, default_value = "mainnet", help = "Index <CHAIN>.")]
-  pub(crate) chain: Chain,
-  #[clap(long, help = "Store index in <DATA_DIR>.")]
-  data_dir: Option<PathBuf>,
-  #[clap(long, help = "Load Bitcoin Core data dir from <BITCOIN_DATA_DIR>.")]
-  bitcoin_data_dir: Option<PathBuf>,
-  #[clap(long, help = "Limit index to <HEIGHT_LIMIT> blocks.")]
-  pub(crate) height_limit: Option<u64>,
-  #[clap(long, help = "Index ordinal ranges")]
-  pub(crate) index_ordinals: bool,
 }
 
 impl Options {

--- a/src/options.rs
+++ b/src/options.rs
@@ -22,6 +22,8 @@ pub(crate) struct Options {
   bitcoin_data_dir: Option<PathBuf>,
   #[clap(long, help = "Limit index to <HEIGHT_LIMIT> blocks.")]
   pub(crate) height_limit: Option<u64>,
+  #[clap(long, help = "")]
+  pub(crate) index_ordinal_ranges: bool,
 }
 
 impl Options {

--- a/src/options.rs
+++ b/src/options.rs
@@ -22,8 +22,8 @@ pub(crate) struct Options {
   bitcoin_data_dir: Option<PathBuf>,
   #[clap(long, help = "Limit index to <HEIGHT_LIMIT> blocks.")]
   pub(crate) height_limit: Option<u64>,
-  #[clap(long, help = "")]
-  pub(crate) index_ordinal_ranges: bool,
+  #[clap(long, help = "Index ordinal ranges")]
+  pub(crate) index_ordinals: bool,
 }
 
 impl Options {

--- a/src/subcommand/server.rs
+++ b/src/subcommand/server.rs
@@ -617,6 +617,10 @@ mod tests {
 
   impl TestServer {
     fn new() -> Self {
+      Self::new_with_args(&[])
+    }
+
+    fn new_with_args(args: &[&str]) -> Self {
       let bitcoin_rpc_server = test_bitcoincore_rpc::spawn();
 
       let tempdir = TempDir::new().unwrap();
@@ -634,10 +638,11 @@ mod tests {
       let url = Url::parse(&format!("http://127.0.0.1:{port}")).unwrap();
 
       let (options, server) = parse_server_args(&format!(
-        "ord --chain regtest --rpc-url {} --cookie-file {} --data-dir {} server --http-port {} --address 127.0.0.1",
+        "ord --chain regtest --rpc-url {} --cookie-file {} --data-dir {} {} server --http-port {} --address 127.0.0.1",
         bitcoin_rpc_server.url(),
         cookiefile.to_str().unwrap(),
         tempdir.path().to_str().unwrap(),
+        args.join(" "),
         port,
       ));
 
@@ -1061,9 +1066,7 @@ mod tests {
   }
   #[test]
   fn output() {
-    let test_server = TestServer::new();
-
-    test_server.assert_response_regex(
+    TestServer::new_with_args(&["--index-ordinals"]).assert_response_regex(
     "/output/4a5e1e4baab89f3a32518a88c31bc87f618f76673e2cc77ab2127b7afdeda33b:0",
     StatusCode::OK,
     ".*<title>Output 4a5e1e4baab89f3a32518a88c31bc87f618f76673e2cc77ab2127b7afdeda33b:0</title>.*<h1>Output <span class=monospace>4a5e1e4baab89f3a32518a88c31bc87f618f76673e2cc77ab2127b7afdeda33b:0</span></h1>
@@ -1080,7 +1083,7 @@ mod tests {
 
   #[test]
   fn unknown_output_returns_404() {
-    TestServer::new().assert_response(
+    TestServer::new_with_args(&["--index-ordinals"]).assert_response(
       "/output/0000000000000000000000000000000000000000000000000000000000000000:0",
       StatusCode::NOT_FOUND,
       "output 0000000000000000000000000000000000000000000000000000000000000000:0 unknown",
@@ -1293,7 +1296,7 @@ next.*",
 
   #[test]
   fn rare() {
-    TestServer::new().assert_response(
+    TestServer::new_with_args(&["--index-ordinals"]).assert_response(
       "/rare.txt",
       StatusCode::OK,
       "ordinal\tsatpoint
@@ -1374,7 +1377,7 @@ next.*",
 
   #[test]
   fn outputs_traversed_are_tracked() {
-    let server = TestServer::new();
+    let server = TestServer::new_with_args(&["--index-ordinals"]);
 
     assert_eq!(
       server
@@ -1410,7 +1413,7 @@ next.*",
 
   #[test]
   fn coinbase_ordinal_ranges_are_tracked() {
-    let server = TestServer::new();
+    let server = TestServer::new_with_args(&["--index-ordinals"]);
 
     assert_eq!(
       server
@@ -1445,7 +1448,7 @@ next.*",
 
   #[test]
   fn split_ordinal_ranges_are_tracked() {
-    let server = TestServer::new();
+    let server = TestServer::new_with_args(&["--index-ordinals"]);
 
     assert_eq!(
       server
@@ -1475,7 +1478,7 @@ next.*",
 
   #[test]
   fn fee_ordinal_ranges_are_tracked() {
-    let server = TestServer::new();
+    let server = TestServer::new_with_args(&["--index-ordinals"]);
 
     assert_eq!(
       server

--- a/tests/find.rs
+++ b/tests/find.rs
@@ -3,7 +3,7 @@ use super::*;
 #[test]
 fn find_command_returns_satpoint_for_ordinal() {
   let rpc_server = test_bitcoincore_rpc::spawn();
-  CommandBuilder::new("find 0")
+  CommandBuilder::new("--index-ordinals find 0")
     .rpc_server(&rpc_server)
     .expected_stdout("4a5e1e4baab89f3a32518a88c31bc87f618f76673e2cc77ab2127b7afdeda33b:0:0\n")
     .run();
@@ -12,7 +12,7 @@ fn find_command_returns_satpoint_for_ordinal() {
 #[test]
 fn unmined_ordinal() {
   let rpc_server = test_bitcoincore_rpc::spawn();
-  CommandBuilder::new("find 5000000000")
+  CommandBuilder::new("--index-ordinals find 5000000000")
     .rpc_server(&rpc_server)
     .expected_stderr("error: ordinal has not been mined as of index height\n")
     .expected_exit_code(1)

--- a/tests/index.rs
+++ b/tests/index.rs
@@ -5,7 +5,7 @@ fn custom_index_size() {
   let rpc_server = test_bitcoincore_rpc::spawn();
   rpc_server.mine_blocks(1);
 
-  let output = CommandBuilder::new("--max-index-size 1mib find 0")
+  let output = CommandBuilder::new("--max-index-size 1mib --index-ordinals find 0")
     .rpc_server(&rpc_server)
     .expected_stdout("4a5e1e4baab89f3a32518a88c31bc87f618f76673e2cc77ab2127b7afdeda33b:0:0\n")
     .run();

--- a/tests/info.rs
+++ b/tests/info.rs
@@ -1,9 +1,9 @@
 use super::*;
 
 #[test]
-fn basic() {
+fn initial() {
   let rpc_server = test_bitcoincore_rpc::spawn();
-  CommandBuilder::new("info")
+  CommandBuilder::new("--index-ordinals info")
     .rpc_server(&rpc_server)
     .stdout_regex(
       r#"\{"blocks_indexed":1,"branch_pages":\d+,"fragmented_bytes":\d+,"free_pages":\d+,"index_file_size":\d+,"leaf_pages":\d+,"metadata_bytes":\d+,"ordinal_ranges":1,"outputs_traversed":1,"page_size":\d+,"stored_bytes":\d+,"transactions":\[\{"starting_block_count":0,"starting_timestamp":\d+\}\],"tree_height":\d+,"utxos_indexed":1\}"#

--- a/tests/list.rs
+++ b/tests/list.rs
@@ -3,18 +3,22 @@ use super::*;
 #[test]
 fn output_found() {
   let rpc_server = test_bitcoincore_rpc::spawn();
-  CommandBuilder::new("list 4a5e1e4baab89f3a32518a88c31bc87f618f76673e2cc77ab2127b7afdeda33b:0")
-    .rpc_server(&rpc_server)
-    .expected_stdout("[0,5000000000)\n")
-    .run();
+  CommandBuilder::new(
+    "--index-ordinals list 4a5e1e4baab89f3a32518a88c31bc87f618f76673e2cc77ab2127b7afdeda33b:0",
+  )
+  .rpc_server(&rpc_server)
+  .expected_stdout("[0,5000000000)\n")
+  .run();
 }
 
 #[test]
 fn output_not_found() {
   let rpc_server = test_bitcoincore_rpc::spawn();
-  CommandBuilder::new("list 0000000000000000000000000000000000000000000000000000000000000000:0")
-    .rpc_server(&rpc_server)
-    .expected_exit_code(1)
-    .expected_stderr("error: output not found\n")
-    .run();
+  CommandBuilder::new(
+    "--index-ordinals list 0000000000000000000000000000000000000000000000000000000000000000:0",
+  )
+  .rpc_server(&rpc_server)
+  .expected_exit_code(1)
+  .expected_stderr("error: output not found\n")
+  .run();
 }

--- a/tests/server.rs
+++ b/tests/server.rs
@@ -39,18 +39,19 @@ fn inscription_page() {
   let rpc_server = test_bitcoincore_rpc::spawn_with(Network::Regtest, "ord");
   rpc_server.mine_blocks(1);
 
-  let output =
-    CommandBuilder::new("--chain regtest wallet inscribe --ordinal 5000000000 --file hello.txt")
-      .write("hello.txt", "HELLOWORLD")
-      .rpc_server(&rpc_server)
-      .stdout_regex("commit\t[[:xdigit:]]{64}\nreveal\t[[:xdigit:]]{64}\n")
-      .run();
+  let output = CommandBuilder::new(
+    "--chain regtest --index-ordinals wallet inscribe --ordinal 5000000000 --file hello.txt",
+  )
+  .write("hello.txt", "HELLOWORLD")
+  .rpc_server(&rpc_server)
+  .stdout_regex("commit\t[[:xdigit:]]{64}\nreveal\t[[:xdigit:]]{64}\n")
+  .run();
 
   let reveal_tx = output.stdout.split("reveal\t").collect::<Vec<&str>>()[1];
 
   rpc_server.mine_blocks(1);
 
-  let ord_server = TestServer::spawn(&rpc_server);
+  let ord_server = TestServer::spawn_with_args(&rpc_server, &["--index-ordinals"]);
 
   ord_server.assert_response_regex(
     &format!("/inscription/{}", reveal_tx),

--- a/tests/test_server.rs
+++ b/tests/test_server.rs
@@ -11,7 +11,7 @@ pub(crate) struct TestServer {
 }
 
 impl TestServer {
-  pub(crate) fn spawn(rpc_server: &test_bitcoincore_rpc::Handle) -> Self {
+  pub(crate) fn spawn_with_args(rpc_server: &test_bitcoincore_rpc::Handle, args: &[&str]) -> Self {
     let tempdir = TempDir::new().unwrap();
     fs::create_dir(tempdir.path().join("regtest")).unwrap();
     fs::write(tempdir.path().join("regtest/.cookie"), "foo:bar").unwrap();
@@ -22,10 +22,11 @@ impl TestServer {
       .port();
 
     let child = Command::new(executable_path("ord")).args(format!(
-      "--chain regtest --rpc-url {} --bitcoin-data-dir {} --data-dir {} server --http-port {port} --address 127.0.0.1",
+      "--chain regtest --rpc-url {} --bitcoin-data-dir {} --data-dir {} {} server --http-port {port} --address 127.0.0.1",
       rpc_server.url(),
       tempdir.path().display(),
-      tempdir.path().display()
+      tempdir.path().display(),
+      args.join(" "),
     ).to_args())
       .env("HOME", tempdir.path())
       .env("ORD_DISABLE_PROGRESS_BAR", "1")


### PR DESCRIPTION
Some concerns with leaving this stuff in place behind a flag:

- extra subcommands in help (find, list, info)
- updater becomes a little more complicated (not incredibly bad though)
- have to maintain and test two configurations (for example, just have tests that exercise error messages when flag is not passed)

jk who cares, we can deal with those problems if and when they come up