### PR TITLE
Set size limit to 1024 on signet and testnet

### DIFF
--- a/src/chain.rs
+++ b/src/chain.rs
@@ -30,6 +30,13 @@ impl Chain {
     }
   }
 
+  pub(crate) fn inscription_content_size_limit(self) -> Option<usize> {
+    match self {
+      Self::Mainnet | Self::Regtest => None,
+      Self::Testnet | Self::Signet => Some(1024),
+    }
+  }
+
   pub(crate) fn genesis_block(self) -> Block {
     bitcoin::blockdata::constants::genesis_block(self.network())
   }

--- a/src/subcommand/wallet/inscribe.rs
+++ b/src/subcommand/wallet/inscribe.rs
@@ -24,7 +24,7 @@ impl Inscribe {
   pub(crate) fn run(self, options: Options) -> Result {
     let client = options.bitcoin_rpc_client_mainnet_forbidden("ord wallet inscribe")?;
 
-    let inscription = Inscription::from_file(self.file)?;
+    let inscription = Inscription::from_file(options.chain, self.file)?;
 
     let index = Index::open(&options)?;
     index.update()?;


### PR DESCRIPTION
Signet and testnet are both low-volume networks without a functioning fee market. Because of the potential for spam, we don't want to allow large inscriptions on those networks. Set the size limit to 1024 bytes for both signet and testnet, which is large enough that we'll exercise the content data chunking, but small enough that spam shouldn't be an issue. Regtest is a private test network, so spam is not an issue, and mainnet has a robust fee market, so large inscriptions will have to pay correspondingly high fees.