### PR TITLE
Avoid `as` conversions

### DIFF
--- a/src/epoch.rs
+++ b/src/epoch.rs
@@ -52,7 +52,7 @@ impl Epoch {
 
   pub(crate) fn starting_ordinal(self) -> Ordinal {
     *Self::STARTING_ORDINALS
-      .get(self.0 as usize)
+      .get(usize::try_from(self.0).unwrap())
       .unwrap_or_else(|| Self::STARTING_ORDINALS.last().unwrap())
   }
 

--- a/src/index.rs
+++ b/src/index.rs
@@ -302,7 +302,7 @@ impl Index {
 
   pub(crate) fn decode_ordinal_range(bytes: OrdinalRangeArray) -> (u64, u64) {
     let raw_base = u64::from_le_bytes([
-      bytes[0], bytes[1], bytes[2], bytes[3], bytes[4], bytes[5], bytes[6], bytes[7],
+      bytes[0], bytes[1], bytes[2], bytes[3], bytes[4], bytes[5], bytes[6], 0,
     ]);
 
     // 51 bit base

--- a/src/index.rs
+++ b/src/index.rs
@@ -301,15 +301,18 @@ impl Index {
   }
 
   pub(crate) fn decode_ordinal_range(bytes: OrdinalRangeArray) -> (u64, u64) {
-    let n = u128::from_le_bytes([
-      bytes[0], bytes[1], bytes[2], bytes[3], bytes[4], bytes[5], bytes[6], bytes[7], bytes[8],
-      bytes[9], bytes[10], 0, 0, 0, 0, 0,
+    let raw_base = u64::from_le_bytes([
+      bytes[0], bytes[1], bytes[2], bytes[3], bytes[4], bytes[5], bytes[6], bytes[7],
     ]);
 
     // 51 bit base
-    let base = (n & ((1 << 51) - 1)) as u64;
+    let base = raw_base & ((1 << 51) - 1);
+
+    let raw_delta =
+      u64::from_le_bytes([bytes[6], bytes[7], bytes[8], bytes[9], bytes[10], 0, 0, 0]);
+
     // 33 bit delta
-    let delta = (n >> 51) as u64;
+    let delta = raw_delta >> 3;
 
     (base, base + delta)
   }
@@ -565,7 +568,7 @@ impl Index {
         })?;
 
         Ok(Blocktime::Expected(
-          Utc::now().timestamp() + 10 * 60 * expected_blocks as i64,
+          Utc::now().timestamp() + 10 * 60 * i64::try_from(expected_blocks).unwrap(),
         ))
       }
     }

--- a/src/index/updater.rs
+++ b/src/index/updater.rs
@@ -251,7 +251,7 @@ impl Updater {
     let mut ordinal_ranges_written = 0;
     let mut outputs_in_block = 0;
 
-    let time = Utc.timestamp_opt(block.header.time as i64, 0).unwrap();
+    let time = Utc.timestamp_opt(block.header.time.into(), 0).unwrap();
 
     log::info!(
       "Block {} at {} with {} transactions…",
@@ -441,7 +441,7 @@ impl Updater {
 
     for (vout, output) in tx.output.iter().enumerate() {
       let outpoint = OutPoint {
-        vout: vout as u32,
+        vout: vout.try_into().unwrap(),
         txid,
       };
       let mut ordinals = Vec::new();
@@ -476,7 +476,7 @@ impl Updater {
         let base = assigned.0;
         let delta = assigned.1 - assigned.0;
 
-        let n = base as u128 | (delta as u128) << 51;
+        let n = u128::from(base) | u128::from(delta) << 51;
 
         ordinals.extend_from_slice(&n.to_le_bytes()[0..11]);
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -3,6 +3,12 @@
   clippy::type_complexity,
   clippy::result_large_err
 )]
+#![deny(
+  clippy::cast_lossless,
+  clippy::cast_possible_truncation,
+  clippy::cast_possible_wrap,
+  clippy::cast_sign_loss
+)]
 
 use {
   self::{

--- a/src/ordinal.rs
+++ b/src/ordinal.rs
@@ -174,12 +174,13 @@ impl Ordinal {
 
     let last = Ordinal::LAST.n() as f64;
 
-    let n = (percentile / 100.0 * last).round() as u64;
+    let n = (percentile / 100.0 * last).round();
 
-    if n > Ordinal::LAST.n() {
+    if n > last {
       bail!("invalid percentile: {}", percentile);
     }
 
+    #[allow(clippy::cast_sign_loss, clippy::cast_possible_truncation)]
     Ok(Ordinal(n as u64))
   }
 }

--- a/src/subcommand/wallet/inscribe.rs
+++ b/src/subcommand/wallet/inscribe.rs
@@ -127,7 +127,7 @@ impl Inscribe {
       input: vec![TxIn {
         previous_output: OutPoint {
           txid: unsigned_commit_tx.txid(),
-          vout: vout as u32,
+          vout: vout.try_into().unwrap(),
         },
         script_sig: script::Builder::new().into_script(),
         witness: Witness::new(),


### PR DESCRIPTION
Casts using `as` often silently truncate, so turn on lints that disallow them and avoid them.