### PR TITLE
Make instruction parsing field agnostic

### DIFF
--- a/src/inscription.rs
+++ b/src/inscription.rs
@@ -93,9 +93,9 @@ impl Inscription {
   pub(crate) fn content(&self) -> Option<Content> {
     let content = self.content.as_ref()?;
 
-    match str::from_utf8(self.content_type.as_ref()?).ok()? {
-      "text/plain;charset=utf-8" => Some(Content::Text(str::from_utf8(content).ok()?)),
-      "image/png" => Some(Content::Png(content)),
+    match self.content_type.as_ref()?.as_slice() {
+      b"text/plain;charset=utf-8" => Some(Content::Text(str::from_utf8(content).ok()?)),
+      b"image/png" => Some(Content::Png(content)),
       _ => None,
     }
   }

--- a/src/inscription.rs
+++ b/src/inscription.rs
@@ -18,8 +18,8 @@ const CONTENT_TYPE_TAG: &[u8] = &[1];
 
 #[derive(Debug, PartialEq)]
 pub(crate) struct Inscription {
-  pub(crate) content: Vec<u8>,
-  pub(crate) content_type: Vec<u8>,
+  pub(crate) content: Option<Vec<u8>>,
+  pub(crate) content_type: Option<Vec<u8>>,
 }
 
 impl Inscription {
@@ -55,8 +55,8 @@ impl Inscription {
     };
 
     Ok(Self {
-      content,
-      content_type: content_type.into(),
+      content: Some(content),
+      content_type: Some(content_type.into()),
     })
   }
 
@@ -64,22 +64,30 @@ impl Inscription {
     builder = builder
       .push_opcode(opcodes::OP_FALSE)
       .push_opcode(opcodes::all::OP_IF)
-      .push_slice(PROTOCOL_ID)
-      .push_slice(CONTENT_TYPE_TAG)
-      .push_slice(&self.content_type)
-      .push_slice(CONTENT_TAG);
+      .push_slice(PROTOCOL_ID);
 
-    for chunk in self.content.chunks(520) {
-      builder = builder.push_slice(chunk);
+    if let Some(content_type) = &self.content_type {
+      builder = builder
+        .push_slice(CONTENT_TYPE_TAG)
+        .push_slice(content_type);
+    }
+
+    if let Some(content) = &self.content {
+      builder = builder.push_slice(CONTENT_TAG);
+      for chunk in content.chunks(520) {
+        builder = builder.push_slice(chunk);
+      }
     }
 
     builder.push_opcode(opcodes::all::OP_ENDIF).into_script()
   }
 
   pub(crate) fn content(&self) -> Option<Content> {
-    match self.content_type.as_slice() {
-      b"text/plain;charset=utf-8" => Some(Content::Text(str::from_utf8(&self.content).ok()?)),
-      b"image/png" => Some(Content::Png(&self.content)),
+    let content = self.content.as_ref()?;
+
+    match self.content_type.as_ref()?.as_slice() {
+      b"text/plain;charset=utf-8" => Some(Content::Text(str::from_utf8(&content).ok()?)),
+      b"image/png" => Some(Content::Png(&content)),
       _ => None,
     }
   }
@@ -164,24 +172,32 @@ impl<'a> InscriptionParser<'a> {
         return Err(InscriptionError::NoInscription);
       }
 
-      if !self.accept(Instruction::PushBytes(CONTENT_TYPE_TAG))? {
-        return Err(InscriptionError::InvalidInscription);
-      }
+      let mut fields: BTreeMap<&[u8], Vec<u8>> = BTreeMap::new();
 
-      let content_type = self.expect_push()?;
-
-      if !self.accept(Instruction::PushBytes(CONTENT_TAG))? {
-        return Err(InscriptionError::InvalidInscription);
-      }
-
-      let mut content = Vec::new();
-      while !self.accept(Instruction::Op(opcodes::all::OP_ENDIF))? {
-        content.extend_from_slice(self.expect_push()?);
+      loop {
+        match self.advance()? {
+          Instruction::PushBytes(CONTENT_TAG) => {
+            let mut content = Vec::new();
+            while !self.accept(Instruction::Op(opcodes::all::OP_ENDIF))? {
+              content.extend_from_slice(self.expect_push()?);
+            }
+            fields.insert(CONTENT_TAG, content);
+            break;
+          }
+          Instruction::PushBytes(tag) => {
+            if fields.contains_key(tag) {
+              return Err(InscriptionError::InvalidInscription);
+            }
+            fields.insert(tag, self.expect_push()?.to_vec());
+          }
+          Instruction::Op(opcodes::all::OP_ENDIF) => break,
+          _ => return Err(InscriptionError::InvalidInscription),
+        }
       }
 
       return Ok(Some(Inscription {
-        content,
-        content_type: content_type.into(),
+        content: fields.remove(CONTENT_TAG),
+        content_type: fields.remove(CONTENT_TYPE_TAG),
       }));
     }
 
@@ -284,6 +300,28 @@ mod tests {
   }
 
   #[test]
+  fn no_content_tag() {
+    assert_eq!(
+      InscriptionParser::parse(&container(&[b"ord", &[1], b"text/plain;charset=utf-8"])),
+      Ok(Inscription {
+        content_type: Some(b"text/plain;charset=utf-8".to_vec()),
+        content: None,
+      }),
+    );
+  }
+
+  #[test]
+  fn no_content_type() {
+    assert_eq!(
+      InscriptionParser::parse(&container(&[b"ord", &[], b"foo"])),
+      Ok(Inscription {
+        content_type: None,
+        content: Some(b"foo".to_vec()),
+      }),
+    );
+  }
+
+  #[test]
   fn valid_content_in_multiple_pushes() {
     assert_eq!(
       InscriptionParser::parse(&container(&[
@@ -306,6 +344,24 @@ mod tests {
         &[1],
         b"text/plain;charset=utf-8",
         &[]
+      ])),
+      Ok(inscription("text/plain;charset=utf-8", "")),
+    );
+  }
+
+  #[test]
+  fn valid_content_in_multiple_empty_pushes() {
+    assert_eq!(
+      InscriptionParser::parse(&container(&[
+        b"ord",
+        &[1],
+        b"text/plain;charset=utf-8",
+        &[],
+        &[],
+        &[],
+        &[],
+        &[],
+        &[],
       ])),
       Ok(inscription("text/plain;charset=utf-8", "")),
     );
@@ -410,7 +466,7 @@ mod tests {
 
     assert_eq!(
       InscriptionParser::parse(&Witness::from_vec(vec![script.into_bytes(), vec![]])),
-      Err(InscriptionError::InvalidInscription)
+      Err(InscriptionError::NoInscription)
     );
   }
 
@@ -431,7 +487,7 @@ mod tests {
   }
 
   #[test]
-  fn unrecognized_content() {
+  fn junk() {
     assert_eq!(
       InscriptionParser::parse(&container(&[
         b"ord",
@@ -442,7 +498,10 @@ mod tests {
         b"ord",
         b"ord"
       ])),
-      Err(InscriptionError::InvalidInscription),
+      Ok(Inscription {
+        content_type: None,
+        content: None,
+      }),
     );
   }
 
@@ -464,30 +523,6 @@ mod tests {
       Inscription::from_transaction(&tx),
       Some(inscription("text/plain;charset=utf-8", "ord")),
     );
-  }
-
-  #[test]
-  fn extract_from_zero_value_transaction() {
-    let script = script::Builder::new()
-      .push_opcode(opcodes::OP_FALSE)
-      .push_opcode(opcodes::all::OP_IF)
-      .push_slice("ord".as_bytes())
-      .push_opcode(opcodes::all::OP_ENDIF)
-      .into_script();
-
-    let tx = Transaction {
-      version: 0,
-      lock_time: bitcoin::PackedLockTime(0),
-      input: vec![TxIn {
-        previous_output: OutPoint::null(),
-        script_sig: Script::new(),
-        sequence: Sequence(0),
-        witness: Witness::from_vec(vec![script.into_bytes(), vec![]]),
-      }],
-      output: Vec::new(),
-    };
-
-    assert_eq!(Inscription::from_transaction(&tx), None);
   }
 
   #[test]

--- a/src/inscription.rs
+++ b/src/inscription.rs
@@ -172,7 +172,7 @@ impl<'a> InscriptionParser<'a> {
         return Err(InscriptionError::NoInscription);
       }
 
-      let mut fields: BTreeMap<&[u8], Vec<u8>> = BTreeMap::new();
+      let mut fields = BTreeMap::new();
 
       loop {
         match self.advance()? {

--- a/src/inscription.rs
+++ b/src/inscription.rs
@@ -286,12 +286,44 @@ mod tests {
   }
 
   #[test]
+  fn duplicate_field() {
+    assert_eq!(
+      InscriptionParser::parse(&container(&[
+        b"ord",
+        &[1],
+        b"text/plain;charset=utf-8",
+        &[1],
+        b"text/plain;charset=utf-8",
+        &[],
+        b"ord",
+      ])),
+      Err(InscriptionError::InvalidInscription),
+    );
+  }
+
+  #[test]
   fn valid() {
     assert_eq!(
       InscriptionParser::parse(&container(&[
         b"ord",
         &[1],
         b"text/plain;charset=utf-8",
+        &[],
+        b"ord",
+      ])),
+      Ok(inscription("text/plain;charset=utf-8", "ord")),
+    );
+  }
+
+  #[test]
+  fn valid_with_unknown_tag() {
+    assert_eq!(
+      InscriptionParser::parse(&container(&[
+        b"ord",
+        &[1],
+        b"text/plain;charset=utf-8",
+        &[2],
+        b"bar",
         &[],
         b"ord",
       ])),

--- a/src/inscription.rs
+++ b/src/inscription.rs
@@ -86,8 +86,8 @@ impl Inscription {
     let content = self.content.as_ref()?;
 
     match self.content_type.as_ref()?.as_slice() {
-      b"text/plain;charset=utf-8" => Some(Content::Text(str::from_utf8(&content).ok()?)),
-      b"image/png" => Some(Content::Png(&content)),
+      b"text/plain;charset=utf-8" => Some(Content::Text(str::from_utf8(content).ok()?)),
+      b"image/png" => Some(Content::Png(content)),
       _ => None,
     }
   }

--- a/src/test.rs
+++ b/src/test.rs
@@ -69,7 +69,7 @@ pub(crate) fn tx_out(value: u64, address: Address) -> TxOut {
 
 pub(crate) fn inscription(content_type: &str, content: impl AsRef<[u8]>) -> Inscription {
   Inscription {
-    content_type: content_type.into(),
-    content: content.as_ref().into(),
+    content_type: Some(content_type.into()),
+    content: Some(content.as_ref().into()),
   }
 }

--- a/src/test.rs
+++ b/src/test.rs
@@ -68,8 +68,5 @@ pub(crate) fn tx_out(value: u64, address: Address) -> TxOut {
 }
 
 pub(crate) fn inscription(content_type: &str, content: impl AsRef<[u8]>) -> Inscription {
-  Inscription {
-    content_type: Some(content_type.into()),
-    content: Some(content.as_ref().into()),
-  }
+  Inscription::new(Some(content_type.into()), Some(content.as_ref().into()))
 }


### PR DESCRIPTION
We want instruction parsing to be simple and stable, so that it is easy to maintain consensus over the set of valid inscriptions.

This changes the inscription parser to be simpler and more generic:

- Unknown fields are ignored
- All fields can be omitted

The only hard errors are:
- Missing magic number
- Non-push instruction
- Duplicated field