### PR TITLE
Support more image content types

### DIFF
--- a/src/inscription.rs
+++ b/src/inscription.rs
@@ -18,7 +18,6 @@ const CONTENT_TYPE_TAG: &[u8] = &[1];
 
 const CONTENT_TYPES: &[(&str, bool, &[&str])] = &[
   ("image/apng", true, &["apng"]),
-  ("image/avif", true, &["avif"]),
   ("image/gif", true, &["gif"]),
   ("image/jpeg", true, &["jpg", "jpeg"]),
   ("image/png", true, &["png"]),

--- a/src/inscription/content_type.rs
+++ b/src/inscription/content_type.rs
@@ -1,0 +1,58 @@
+use super::*;
+
+const TABLE: &[(&str, bool, &[&str])] = &[
+  ("image/apng", true, &["apng"]),
+  ("image/gif", true, &["gif"]),
+  ("image/jpeg", true, &["jpg", "jpeg"]),
+  ("image/png", true, &["png"]),
+  ("image/webp", true, &["webp"]),
+  ("text/plain;charset=utf-8", false, &["txt"]),
+];
+
+lazy_static! {
+  static ref IMAGE_CONTENT_TYPES: HashSet<&'static str> = TABLE
+    .iter()
+    .filter(|(_, image, _)| *image)
+    .map(|(content_type, _, _)| *content_type)
+    .collect();
+}
+
+pub(crate) fn is_image(content_type: &str) -> bool {
+  IMAGE_CONTENT_TYPES.contains(content_type)
+}
+
+pub(crate) fn for_extension(extension: &str) -> Result<&'static str, Error> {
+  for (content_type, _, extensions) in TABLE {
+    if extensions.contains(&extension) {
+      return Ok(content_type);
+    }
+  }
+
+  Err(anyhow!(
+    "file extension `.{extension}`, supported extensions: {}",
+    TABLE
+      .iter()
+      .map(|(_, _, extensions)| extensions[0])
+      .collect::<Vec<&str>>()
+      .join(" "),
+  ))
+}
+
+#[cfg(test)]
+mod tests {
+  #[test]
+  fn is_image() {
+    assert!(super::is_image("image/apng"));
+    assert!(!super::is_image("foo"));
+  }
+
+  #[test]
+  fn for_extension() {
+    assert_eq!(super::for_extension("jpg").unwrap(), "image/jpeg");
+    assert_eq!(super::for_extension("jpeg").unwrap(), "image/jpeg");
+    assert_eq!(
+      super::for_extension("foo").unwrap_err().to_string(),
+      "file extension `.foo`, supported extensions: apng gif jpg png webp txt"
+    );
+  }
+}

--- a/src/inscription/content_type.rs
+++ b/src/inscription/content_type.rs
@@ -29,7 +29,7 @@ pub(crate) fn for_extension(extension: &str) -> Result<&'static str, Error> {
   }
 
   Err(anyhow!(
-    "file extension `.{extension}`, supported extensions: {}",
+    "unsupported file extension `.{extension}`, supported extensions: {}",
     TABLE
       .iter()
       .map(|(_, _, extensions)| extensions[0])
@@ -52,7 +52,7 @@ mod tests {
     assert_eq!(super::for_extension("jpeg").unwrap(), "image/jpeg");
     assert_eq!(
       super::for_extension("foo").unwrap_err().to_string(),
-      "file extension `.foo`, supported extensions: apng gif jpg png webp txt"
+      "unsupported file extension `.foo`, supported extensions: apng gif jpg png webp txt"
     );
   }
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -42,11 +42,12 @@ use {
   clap::{ArgGroup, Parser},
   derive_more::{Display, FromStr},
   html_escaper::{Escape, Trusted},
+  lazy_static::lazy_static,
   regex::Regex,
   serde::{Deserialize, Serialize},
   std::{
     cmp::Ordering,
-    collections::{BTreeMap, VecDeque},
+    collections::{BTreeMap, HashSet, VecDeque},
     env,
     fmt::{self, Display, Formatter},
     fs, io,

--- a/src/subcommand/server.rs
+++ b/src/subcommand/server.rs
@@ -17,7 +17,6 @@ use {
     Router,
   },
   axum_server::Handle,
-  lazy_static::lazy_static,
   rust_embed::RustEmbed,
   rustls_acme::{
     acme::{LETS_ENCRYPT_PRODUCTION_DIRECTORY, LETS_ENCRYPT_STAGING_DIRECTORY},

--- a/tests/wallet.rs
+++ b/tests/wallet.rs
@@ -291,7 +291,7 @@ fn inscribe_unknown_file_extension() {
   .write("pepe.xyz", [1; 520])
   .rpc_server(&rpc_server)
   .expected_exit_code(1)
-  .stderr_regex(r"error: file extension `\.xyz`, supported extensions: apng .*\n")
+  .stderr_regex(r"error: unsupported file extension `\.xyz`, supported extensions: apng .*\n")
   .run();
 }
 

--- a/tests/wallet.rs
+++ b/tests/wallet.rs
@@ -286,12 +286,12 @@ fn inscribe_unknown_file_extension() {
   let txid = rpc_server.mine_blocks(1)[0].txdata[0].txid();
 
   CommandBuilder::new(format!(
-    "--chain regtest wallet inscribe --satpoint {txid}:0:0 --file pepe.jpg"
+    "--chain regtest wallet inscribe --satpoint {txid}:0:0 --file pepe.xyz"
   ))
-  .write("pepe.jpg", [1; 520])
+  .write("pepe.xyz", [1; 520])
   .rpc_server(&rpc_server)
   .expected_exit_code(1)
-  .expected_stderr("error: unrecognized file extension `.jpg`, only .txt, .png and .gif accepted\n")
+  .stderr_regex(r"error: file extension `\.xyz`, supported extensions: apng .*\n")
   .run();
 }
 


### PR DESCRIPTION
Added all common and widely supported image content types. Many of them have improved compression, which make them interesting for resource constrained inscriptions.

I was going to add avif, but it isn't widely supported yet: https://caniuse.com/?search=avif