### PR TITLE
Support SVG and HTML inscriptions

### DIFF
--- a/src/content.rs
+++ b/src/content.rs
@@ -1,5 +1,6 @@
 #[derive(Debug, PartialEq)]
 pub(crate) enum Content<'a> {
+  Html,
   Image,
   Svg,
   Text(&'a str),

--- a/src/content.rs
+++ b/src/content.rs
@@ -1,5 +1,6 @@
 #[derive(Debug, PartialEq)]
 pub(crate) enum Content<'a> {
-  Text(&'a str),
   Image,
+  Svg,
+  Text(&'a str),
 }

--- a/src/content.rs
+++ b/src/content.rs
@@ -1,7 +1,6 @@
 #[derive(Debug, PartialEq)]
 pub(crate) enum Content<'a> {
-  Html,
+  IFrame,
   Image,
-  Svg,
   Text(&'a str),
 }

--- a/src/inscription.rs
+++ b/src/inscription.rs
@@ -89,7 +89,8 @@ impl Inscription {
     let content = self.content.as_ref()?;
 
     match self.content_type()? {
-      "text/plain;charset=utf-8" => Some(Content::Text(str::from_utf8(content).ok()?)),
+      content_type::SVG => Some(Content::Svg),
+      content_type::TEXT => Some(Content::Text(str::from_utf8(content).ok()?)),
       content_type if content_type::is_image(content_type) => Some(Content::Image),
       _ => None,
     }

--- a/src/inscription.rs
+++ b/src/inscription.rs
@@ -89,8 +89,7 @@ impl Inscription {
     let content = self.content.as_ref()?;
 
     match self.content_type()? {
-      content_type::HTML => Some(Content::Html),
-      content_type::SVG => Some(Content::Svg),
+      content_type::HTML | content_type::SVG => Some(Content::IFrame),
       content_type::TEXT => Some(Content::Text(str::from_utf8(content).ok()?)),
       content_type if content_type::is_image(content_type) => Some(Content::Image),
       _ => None,
@@ -117,7 +116,7 @@ impl Inscription {
   }
 
   pub(crate) fn is_graphical(&self) -> bool {
-    matches!(self.content(), Some(Content::Image) | Some(Content::Svg))
+    matches!(self.content(), Some(Content::Image) | Some(Content::IFrame))
   }
 }
 

--- a/src/inscription.rs
+++ b/src/inscription.rs
@@ -116,7 +116,7 @@ impl Inscription {
   }
 
   pub(crate) fn is_graphical(&self) -> bool {
-    matches!(self.content(), Some(Content::Image))
+    matches!(self.content(), Some(Content::Image) | Some(Content::Svg))
   }
 }
 
@@ -713,6 +713,7 @@ mod tests {
     assert!(inscription("image/png", []).is_graphical());
     assert!(!inscription("foo", []).is_graphical());
     assert!(inscription("image/gif", []).is_graphical());
+    assert!(inscription("image/svg+xml", []).is_graphical());
     assert!(!Inscription::new(None, Some(Vec::new())).is_graphical());
   }
 }

--- a/src/inscription.rs
+++ b/src/inscription.rs
@@ -89,6 +89,7 @@ impl Inscription {
     let content = self.content.as_ref()?;
 
     match self.content_type()? {
+      content_type::HTML => Some(Content::Html),
       content_type::SVG => Some(Content::Svg),
       content_type::TEXT => Some(Content::Text(str::from_utf8(content).ok()?)),
       content_type if content_type::is_image(content_type) => Some(Content::Image),

--- a/src/inscription/content_type.rs
+++ b/src/inscription/content_type.rs
@@ -1,12 +1,16 @@
 use super::*;
 
+pub const TEXT: &str = "text/plain;charset=utf-8";
+pub const SVG: &str = "image/svg+xml";
+
 const TABLE: &[(&str, bool, &[&str])] = &[
   ("image/apng", true, &["apng"]),
   ("image/gif", true, &["gif"]),
   ("image/jpeg", true, &["jpg", "jpeg"]),
   ("image/png", true, &["png"]),
   ("image/webp", true, &["webp"]),
-  ("text/plain;charset=utf-8", false, &["txt"]),
+  (SVG, true, &["svg"]),
+  (TEXT, false, &["txt"]),
 ];
 
 lazy_static! {
@@ -52,7 +56,7 @@ mod tests {
     assert_eq!(super::for_extension("jpeg").unwrap(), "image/jpeg");
     assert_eq!(
       super::for_extension("foo").unwrap_err().to_string(),
-      "unsupported file extension `.foo`, supported extensions: apng gif jpg png webp txt"
+      "unsupported file extension `.foo`, supported extensions: apng gif jpg png webp svg txt"
     );
   }
 }

--- a/src/inscription/content_type.rs
+++ b/src/inscription/content_type.rs
@@ -1,7 +1,8 @@
 use super::*;
 
-pub const TEXT: &str = "text/plain;charset=utf-8";
+pub const HTML: &str = "text/html;charset=utf-8";
 pub const SVG: &str = "image/svg+xml";
+pub const TEXT: &str = "text/plain;charset=utf-8";
 
 const TABLE: &[(&str, bool, &[&str])] = &[
   ("image/apng", true, &["apng"]),
@@ -9,6 +10,7 @@ const TABLE: &[(&str, bool, &[&str])] = &[
   ("image/jpeg", true, &["jpg", "jpeg"]),
   ("image/png", true, &["png"]),
   ("image/webp", true, &["webp"]),
+  (HTML, false, &["html"]),
   (SVG, true, &["svg"]),
   (TEXT, false, &["txt"]),
 ];
@@ -56,7 +58,7 @@ mod tests {
     assert_eq!(super::for_extension("jpeg").unwrap(), "image/jpeg");
     assert_eq!(
       super::for_extension("foo").unwrap_err().to_string(),
-      "unsupported file extension `.foo`, supported extensions: apng gif jpg png webp svg txt"
+      "unsupported file extension `.foo`, supported extensions: apng gif jpg png webp html svg txt"
     );
   }
 }

--- a/src/subcommand/server.rs
+++ b/src/subcommand/server.rs
@@ -675,7 +675,7 @@ impl Server {
           (header::CONTENT_TYPE, content_type),
           (
             header::CONTENT_SECURITY_POLICY,
-            "default-src 'none'".to_string(),
+            "default-src 'none' 'unsafe-eval' 'unsafe-inline'".to_string(),
           ),
         ],
         content,

--- a/src/subcommand/server.rs
+++ b/src/subcommand/server.rs
@@ -669,7 +669,19 @@ impl Server {
       ServerError::NotFound(format!("inscription {inscription_id} has no content"))
     })?;
 
-    Ok(([(header::CONTENT_TYPE, content_type)], content).into_response())
+    Ok(
+      (
+        [
+          (header::CONTENT_TYPE, content_type),
+          (
+            header::CONTENT_SECURITY_POLICY,
+            "default-src 'none'".to_string(),
+          ),
+        ],
+        content,
+      )
+        .into_response(),
+    )
   }
 
   fn content_response(inscription: Inscription) -> Option<(String, Vec<u8>)> {

--- a/src/subcommand/server/templates/content.rs
+++ b/src/subcommand/server/templates/content.rs
@@ -14,7 +14,7 @@ impl<'a> Display for ContentHtml<'a> {
         write!(f, "</pre>")
       }
       Some(Content::Image) => write!(f, "<img src=/content/{}>", self.inscription_id),
-      Some(Content::Svg) => write!(f, "<iframe src=/content/{}>", self.inscription_id),
+      Some(Content::Svg) => write!(f, "<iframe src=/content/{}></iframe>", self.inscription_id),
       None => write!(f, "<p>UNKNOWN</p>"),
     }
   }

--- a/src/subcommand/server/templates/content.rs
+++ b/src/subcommand/server/templates/content.rs
@@ -51,7 +51,7 @@ mod tests {
   }
 
   #[test]
-  fn svg() {
+  fn iframe() {
     assert_eq!(
       ContentHtml {
         content: Some(Content::IFrame),

--- a/src/subcommand/server/templates/content.rs
+++ b/src/subcommand/server/templates/content.rs
@@ -14,7 +14,9 @@ impl<'a> Display for ContentHtml<'a> {
         write!(f, "</pre>")
       }
       Some(Content::Image) => write!(f, "<img src=/content/{}>", self.inscription_id),
-      Some(Content::Svg) => write!(f, "<iframe src=/content/{}></iframe>", self.inscription_id),
+      Some(Content::Svg | Content::Html) => {
+        write!(f, "<iframe src=/content/{}></iframe>", self.inscription_id)
+      }
       None => write!(f, "<p>UNKNOWN</p>"),
     }
   }

--- a/src/subcommand/server/templates/content.rs
+++ b/src/subcommand/server/templates/content.rs
@@ -14,6 +14,7 @@ impl<'a> Display for ContentHtml<'a> {
         write!(f, "</pre>")
       }
       Some(Content::Image) => write!(f, "<img src=/content/{}>", self.inscription_id),
+      Some(Content::Svg) => write!(f, "<iframe src=/content/{}>", self.inscription_id),
       None => write!(f, "<p>UNKNOWN</p>"),
     }
   }

--- a/src/subcommand/server/templates/content.rs
+++ b/src/subcommand/server/templates/content.rs
@@ -21,3 +21,56 @@ impl<'a> Display for ContentHtml<'a> {
     }
   }
 }
+
+#[cfg(test)]
+mod tests {
+  use super::*;
+
+  #[test]
+  fn text() {
+    assert_eq!(
+      ContentHtml {
+        content: Some(Content::Text("foo")),
+        inscription_id: txid(1),
+      }
+      .to_string(),
+      "<pre>foo</pre>"
+    );
+  }
+
+  #[test]
+  fn image() {
+    assert_eq!(
+      ContentHtml {
+        content: Some(Content::Image),
+        inscription_id: txid(1),
+      }
+      .to_string(),
+      "<img src=/content/1111111111111111111111111111111111111111111111111111111111111111>"
+    );
+  }
+
+  #[test]
+  fn svg() {
+    assert_eq!(
+      ContentHtml {
+        content: Some(Content::Svg),
+        inscription_id: txid(1),
+      }
+      .to_string(),
+      "<iframe src=/content/1111111111111111111111111111111111111111111111111111111111111111></iframe>"
+    );
+  }
+
+  #[test]
+  fn html() {
+    assert_eq!(
+      ContentHtml {
+        content: Some(Content::Svg),
+        inscription_id: txid(1),
+      }
+      .to_string(),
+      "<iframe src=/content/1111111111111111111111111111111111111111111111111111111111111111></iframe>"
+    );
+  }
+}

--- a/src/subcommand/server/templates/content.rs
+++ b/src/subcommand/server/templates/content.rs
@@ -14,7 +14,7 @@ impl<'a> Display for ContentHtml<'a> {
         write!(f, "</pre>")
       }
       Some(Content::Image) => write!(f, "<img src=/content/{}>", self.inscription_id),
-      Some(Content::Svg | Content::Html) => {
+      Some(Content::IFrame) => {
         write!(f, "<iframe src=/content/{}></iframe>", self.inscription_id)
       }
       None => write!(f, "<p>UNKNOWN</p>"),
@@ -54,19 +54,7 @@ mod tests {
   fn svg() {
     assert_eq!(
       ContentHtml {
-        content: Some(Content::Svg),
-        inscription_id: txid(1),
-      }
-      .to_string(),
-      "<iframe src=/content/1111111111111111111111111111111111111111111111111111111111111111></iframe>"
-    );
-  }
-
-  #[test]
-  fn html() {
-    assert_eq!(
-      ContentHtml {
-        content: Some(Content::Svg),
+        content: Some(Content::IFrame),
         inscription_id: txid(1),
       }
       .to_string(),

--- a/static/index.css
+++ b/static/index.css
@@ -188,6 +188,11 @@ a.mythic {
   image-rendering: pixelated;
 }
 
+.content iframe {
+  min-width: 50%;
+  border: none;
+}
+
 a.content {
   color: inherit;
   text-decoration: none;

--- a/static/index.css
+++ b/static/index.css
@@ -179,9 +179,8 @@ a.mythic {
 }
 
 .inscriptions a iframe {
-  overflow: auto;
-  max-width: 100%;
-  min-width: 100%;
+  width: 100%;
+  height: 100%;
 }
 
 .content {
@@ -196,11 +195,13 @@ a.mythic {
 
 iframe {
   border: none;
+  pointer-events: none;
 }
 
 .content iframe {
-  min-width: 50%;
+  aspect-ratio: 1 / 1;
   border: none;
+  min-width: 50%;
 }
 
 a.content {

--- a/static/index.css
+++ b/static/index.css
@@ -178,6 +178,12 @@ a.mythic {
   image-rendering: pixelated;
 }
 
+.inscriptions a iframe {
+  overflow: auto;
+  max-width: 100%;
+  min-width: 100%;
+}
+
 .content {
   display: flex;
   justify-content: center;
@@ -186,6 +192,10 @@ a.mythic {
 .content img {
   min-width: 50%;
   image-rendering: pixelated;
+}
+
+iframe {
+  border: none;
 }
 
 .content iframe {

--- a/tests/server.rs
+++ b/tests/server.rs
@@ -177,7 +177,7 @@ fn inscription_content() {
   );
   assert_eq!(
     response.headers().get("content-security-policy").unwrap(),
-    "default-src 'none'"
+    "default-src 'none' 'unsafe-eval' 'unsafe-inline'"
   );
   assert_eq!(response.bytes().unwrap(), "HELLOWORLD");
 }

--- a/tests/server.rs
+++ b/tests/server.rs
@@ -175,6 +175,10 @@ fn inscription_content() {
     response.headers().get("content-type").unwrap(),
     "text/plain;charset=utf-8"
   );
+  assert_eq!(
+    response.headers().get("content-security-policy").unwrap(),
+    "default-src 'none'"
+  );
   assert_eq!(response.bytes().unwrap(), "HELLOWORLD");
 }
 


### PR DESCRIPTION
This was easier than I thought. This serves all content with a CSP header value of `default-src 'none'`. When content is loaded in an iframe with this CSP, all outgoing requests from the iframe are disallowed. We can then serve SVG and HTML content in frames, and they can't make outgoing requests, lessening security concerns and avoiding breakage and references to off-chain content.