### PR TITLE
Add white background to inscription content

### DIFF
--- a/src/subcommand/server/templates/content.rs
+++ b/src/subcommand/server/templates/content.rs
@@ -13,9 +13,17 @@ impl<'a> Display for ContentHtml<'a> {
         text.escape(f, false)?;
         write!(f, "</pre>")
       }
-      Some(Content::Image) => write!(f, "<img src=/content/{}>", self.inscription_id),
+      Some(Content::Image) => write!(
+        f,
+        "<img class=inscription src=/content/{}>",
+        self.inscription_id
+      ),
       Some(Content::IFrame) => {
-        write!(f, "<iframe src=/content/{}></iframe>", self.inscription_id)
+        write!(
+          f,
+          "<iframe class=inscription src=/content/{}></iframe>",
+          self.inscription_id
+        )
       }
       None => write!(f, "<p>UNKNOWN</p>"),
     }

--- a/src/subcommand/server/templates/content.rs
+++ b/src/subcommand/server/templates/content.rs
@@ -35,6 +35,18 @@ mod tests {
   use super::*;
 
   #[test]
+  fn unknown() {
+    assert_eq!(
+      ContentHtml {
+        content: None,
+        inscription_id: txid(1),
+      }
+      .to_string(),
+      "<p>UNKNOWN</p>"
+    );
+  }
+
+  #[test]
   fn text() {
     assert_eq!(
       ContentHtml {
@@ -47,6 +59,18 @@ mod tests {
   }
 
   #[test]
+  fn text_is_escaped() {
+    assert_eq!(
+      ContentHtml {
+        content: Some(Content::Text("<script>alert('hello!')</script>")),
+        inscription_id: txid(1),
+      }
+      .to_string(),
+      "<pre>&lt;script&gt;alert(&apos;hello!&apos;)&lt;/script&gt;</pre>",
+    );
+  }
+
+  #[test]
   fn image() {
     assert_eq!(
       ContentHtml {
@@ -54,7 +78,7 @@ mod tests {
         inscription_id: txid(1),
       }
       .to_string(),
-      "<img src=/content/1111111111111111111111111111111111111111111111111111111111111111>"
+      "<img class=inscription src=/content/1111111111111111111111111111111111111111111111111111111111111111>"
     );
   }
 
@@ -66,7 +90,7 @@ mod tests {
         inscription_id: txid(1),
       }
       .to_string(),
-      "<iframe src=/content/1111111111111111111111111111111111111111111111111111111111111111></iframe>"
+      "<iframe class=inscription src=/content/1111111111111111111111111111111111111111111111111111111111111111></iframe>"
     );
   }
 }

--- a/src/subcommand/server/templates/inscription.rs
+++ b/src/subcommand/server/templates/inscription.rs
@@ -23,7 +23,7 @@ mod tests {
   use super::*;
 
   #[test]
-  fn txt_inscription() {
+  fn html() {
     pretty_assert_eq!(
       InscriptionHtml {
         genesis_height: 0,
@@ -45,72 +45,6 @@ mod tests {
           <dd>10 bytes</dd>
           <dt>content type</dt>
           <dd>text/plain;charset=utf-8</dd>
-          <dt>genesis height</dt>
-          <dd>0</dd>
-          <dt>genesis transaction</dt>
-          <dd><a class=monospace href=/tx/ec90757eb3b164aa43fc548faa2fa0c52025494f2c15d5ddf11260b4034ac6dc>ec90757eb3b164aa43fc548faa2fa0c52025494f2c15d5ddf11260b4034ac6dc</a></dd>
-          <dt>location</dt>
-          <dd class=monospace>1111111111111111111111111111111111111111111111111111111111111111:1:0</dd>
-        </dl>
-      "
-      .unindent()
-    );
-  }
-
-  #[test]
-  fn png_inscription() {
-    pretty_assert_eq!(
-      InscriptionHtml {
-        genesis_height: 0,
-        inscription_id: InscriptionId::from_str(
-          "ec90757eb3b164aa43fc548faa2fa0c52025494f2c15d5ddf11260b4034ac6dc"
-        )
-        .unwrap(),
-        inscription: inscription("image/png", [1; 100]),
-        satpoint: satpoint(1, 0),
-      }
-      .to_string(),
-      "
-        <h1>Inscription ec90757eb3b164aa43fc548faa2fa0c52025494f2c15d5ddf11260b4034ac6dc</h1>
-        <a class=content href=/content/ec90757eb3b164aa43fc548faa2fa0c52025494f2c15d5ddf11260b4034ac6dc>
-        <img src=/content/ec90757eb3b164aa43fc548faa2fa0c52025494f2c15d5ddf11260b4034ac6dc>
-        </a>
-        <dl>
-          <dt>content size</dt>
-          <dd>100 bytes</dd>
-          <dt>content type</dt>
-          <dd>image/png</dd>
-          <dt>genesis height</dt>
-          <dd>0</dd>
-          <dt>genesis transaction</dt>
-          <dd><a class=monospace href=/tx/ec90757eb3b164aa43fc548faa2fa0c52025494f2c15d5ddf11260b4034ac6dc>ec90757eb3b164aa43fc548faa2fa0c52025494f2c15d5ddf11260b4034ac6dc</a></dd>
-          <dt>location</dt>
-          <dd class=monospace>1111111111111111111111111111111111111111111111111111111111111111:1:0</dd>
-        </dl>
-      "
-      .unindent()
-    );
-  }
-
-  #[test]
-  fn empty_inscription() {
-    pretty_assert_eq!(
-      InscriptionHtml {
-        genesis_height: 0,
-        inscription_id: InscriptionId::from_str(
-          "ec90757eb3b164aa43fc548faa2fa0c52025494f2c15d5ddf11260b4034ac6dc"
-        )
-        .unwrap(),
-        inscription: Inscription::new(None, None),
-        satpoint: satpoint(1, 0),
-      }
-      .to_string(),
-      "
-        <h1>Inscription ec90757eb3b164aa43fc548faa2fa0c52025494f2c15d5ddf11260b4034ac6dc</h1>
-        <a class=content href=/content/ec90757eb3b164aa43fc548faa2fa0c52025494f2c15d5ddf11260b4034ac6dc>
-        <p>UNKNOWN</p>
-        </a>
-        <dl>
           <dt>genesis height</dt>
           <dd>0</dd>
           <dt>genesis transaction</dt>

--- a/static/index.css
+++ b/static/index.css
@@ -171,16 +171,16 @@ a.mythic {
   border-radius: 2%;
 }
 
-.inscriptions a img {
+.inscriptions img.inscription {
   overflow: auto;
   max-width: 100%;
   min-width: 100%;
-  image-rendering: pixelated;
 }
 
-.inscriptions a iframe {
-  width: 100%;
-  height: 100%;
+.inscriptions iframe.inscription {
+  width: 102%;
+  height: 102%;
+  overflow: hidden;
 }
 
 .content {
@@ -190,7 +190,6 @@ a.mythic {
 
 .content img {
   min-width: 50%;
-  image-rendering: pixelated;
 }
 
 iframe {
@@ -207,4 +206,15 @@ iframe {
 a.content {
   color: inherit;
   text-decoration: none;
+}
+
+img.inscription {
+  image-rendering: pixelated;
+  background-color: white;
+}
+
+iframe.inscription {
+  border: none;
+  pointer-events: none;
+  background-color: white;
 }

--- a/static/index.css
+++ b/static/index.css
@@ -178,8 +178,8 @@ a.mythic {
 }
 
 .inscriptions iframe.inscription {
-  width: 102%;
-  height: 102%;
+  width: 101%;
+  height: 101%;
   overflow: hidden;
 }
 

--- a/tests/wallet.rs
+++ b/tests/wallet.rs
@@ -308,7 +308,7 @@ fn inscribe_png() {
   ord_server.assert_response_regex(
     "/sat/5000000000",
     &format!(
-      ".*<dt>inscription</dt>\n  <dd><a href=/inscription/{txid}><img src=/content/{txid}.*"
+      ".*<dt>inscription</dt>\n  <dd><a href=/inscription/{txid}><img class=inscription src=/content/{txid}.*"
     ),
   )
 }
@@ -684,7 +684,7 @@ fn inscribe_gif() {
   ord_server.assert_response_regex(
     "/sat/5000000000",
     &format!(
-      ".*<dt>inscription</dt>\n  <dd><a href=/inscription/{txid}><img src=/content/{txid}.*"
+      ".*<dt>inscription</dt>\n  <dd><a href=/inscription/{txid}><img class=inscription src=/content/{txid}.*"
     ),
   )
 }


### PR DESCRIPTION
Without 101% width and height I was getting a weird issue where SVG inscriptions on the main page would display with a white border on one side.

# Before

<img width="1090" alt="Screen Shot 2022-12-22 at 1 20 26 PM" src="https://user-images.githubusercontent.com/1945/209228121-0dd6e61f-3f9c-46b1-bf47-bcab60e47d9f.png">
<img width="1090" alt="Screen Shot 2022-12-22 at 1 20 31 PM" src="https://user-images.githubusercontent.com/1945/209228125-3aaf9643-bde9-48ce-81b6-561c6a0b1f34.png">

# After

<img width="1090" alt="Screen Shot 2022-12-22 at 1 20 17 PM" src="https://user-images.githubusercontent.com/1945/209228206-664de65b-95d1-41cc-a525-c0b4c3f799b7.png">
<img width="1090" alt="Screen Shot 2022-12-22 at 1 20 40 PM" src="https://user-images.githubusercontent.com/1945/209228214-6822eeac-a6e4-4080-a90f-289fe8100407.png">

