### PR TITLE
Add content-encoding

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -81,6 +81,21 @@ dependencies = [
 ]
 
 [[package]]
+name = "alloc-no-stdlib"
+version = "2.0.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cc7bb162ec39d46ab1ca8c77bf72e890535becd1751bb45f64c597edb4c8c6b3"
+
+[[package]]
+name = "alloc-stdlib"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "94fb8275041c72129eb51b7d0322c29b8387a0386127718b096429201a5d6ece"
+dependencies = [
+ "alloc-no-stdlib",
+]
+
+[[package]]
 name = "android_system_properties"
 version = "0.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -358,6 +373,7 @@ dependencies = [
  "bitflags",
  "bytes",
  "futures-util",
+ "headers",
  "http",
  "http-body",
  "hyper",
@@ -527,6 +543,27 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn",
+]
+
+[[package]]
+name = "brotli"
+version = "3.3.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a1a0b1dbcc8ae29329621f8d4f0d835787c1c38bb1401979b49d13b0b305ff68"
+dependencies = [
+ "alloc-no-stdlib",
+ "alloc-stdlib",
+ "brotli-decompressor",
+]
+
+[[package]]
+name = "brotli-decompressor"
+version = "2.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "59ad2d4653bf5ca36ae797b1f4bb4dbddb60ce49ca4aed8a2ce4829f60425b80"
+dependencies = [
+ "alloc-no-stdlib",
+ "alloc-stdlib",
 ]
 
 [[package]]
@@ -1287,6 +1324,31 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8a9ee70c43aaf417c914396645a0fa852624801b24ebb7ae78fe8272889ac888"
 
 [[package]]
+name = "headers"
+version = "0.3.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f3e372db8e5c0d213e0cd0b9be18be2aca3d44cf2fe30a9d46a65581cd454584"
+dependencies = [
+ "base64 0.13.1",
+ "bitflags",
+ "bytes",
+ "headers-core",
+ "http",
+ "httpdate",
+ "mime",
+ "sha1 0.10.5",
+]
+
+[[package]]
+name = "headers-core"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e7f66481bfee273957b1f20485a4ff3362987f85b2c236580d81b4eb7a326429"
+dependencies = [
+ "http",
+]
+
+[[package]]
 name = "heck"
 version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2000,6 +2062,7 @@ dependencies = [
  "base64 0.20.0",
  "bitcoin",
  "boilerplate",
+ "brotli",
  "chrono",
  "clap",
  "ctrlc",
@@ -2010,7 +2073,6 @@ dependencies = [
  "futures 0.3.25",
  "hex",
  "html-escaper",
- "http",
  "indicatif",
  "lazy_static",
  "log",
@@ -2811,6 +2873,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "sha1"
+version = "0.10.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f04293dc80c3993519f2d7f6f511707ee7094fe0c6d3406feb330cdb3540eba3"
+dependencies = [
+ "cfg-if 1.0.0",
+ "cpufeatures",
+ "digest 0.10.6",
+]
+
+[[package]]
 name = "sha1_smol"
 version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2970,7 +3043,7 @@ dependencies = [
  "serde",
  "serde_derive",
  "serde_json",
- "sha1",
+ "sha1 0.6.1",
  "syn",
 ]
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,11 +13,12 @@ members = [".", "test-bitcoincore-rpc"]
 
 [dependencies]
 anyhow = { version = "1.0.56", features = ["backtrace"] }
-axum = "0.6.1"
+axum = { version = "0.6.1", features = ["headers"] }
 axum-server = "0.4.0"
 base64 = "0.20.0"
 bitcoin = { version = "0.29.1", features = ["rand"] }
 boilerplate = { version = "0.2.3", features = ["axum"] }
+brotli = "3.3.4"
 chrono = "0.4.19"
 clap = { version = "3.1.0", features = ["derive"] }
 ctrlc = "3.2.1"
@@ -27,7 +28,6 @@ env_logger = "0.10.0"
 futures = "0.3.21"
 hex = "0.4.3"
 html-escaper = "0.2.0"
-http = "0.2.6"
 indicatif = "0.17.1"
 lazy_static = "1.4.0"
 log = "0.4.14"

--- a/src/inscription.rs
+++ b/src/inscription.rs
@@ -70,7 +70,7 @@ impl Inscription {
 
     let compressed = compress(&content);
 
-    if compressed.len() < content.len() + 1 + "br".len() {
+    if compressed.len() < content.len() + 1 + 1 + "br".len() {
       Ok(Self {
         content: Some(compressed),
         content_type: Some(content_type.into()),

--- a/src/main.rs
+++ b/src/main.rs
@@ -47,7 +47,7 @@ use {
   serde::{Deserialize, Serialize},
   std::{
     cmp::Ordering,
-    collections::{BTreeMap, HashSet, VecDeque},
+    collections::{BTreeMap, HashMap, HashSet, VecDeque},
     env,
     fmt::{self, Display, Formatter},
     fs, io,


### PR DESCRIPTION
Working on adding compression, but it's a bit tricky:

- A response with `Content-Encoding` should only be sent in response to a request with an appropriate `Accept-Encoding`. This means that the ord server can't just blindly respond with compressed content in response to `/content` requests. It must decompress the content if the request doesn't pass a `Accept-Encoding` header with the content's `Content-Encoding`

- Text content is inserted into a template on the server side, so compressed text content must be uncompressed server-side regardless

Uncompressing server-side is tricky.

Content is untrusted, so we have to avoid zip-bombs. However, it seems like always decompressing server-side is probably the way to go. Later, we can optimize by passing content through untouched if the client sends us an `Accept-Encoding` which matches the `Content-Encoding`.