### PR TITLE
#[cfg(test)] only works for unit tests

### DIFF
--- a/src/subcommand/server.rs
+++ b/src/subcommand/server.rs
@@ -210,19 +210,16 @@ impl Server {
       #[cfg(not(test))]
       {
         (self.address.as_str(), port)
-          .to_socket_addrs()?
-          .next()
-          .ok_or_else(|| anyhow!("failed to get socket addrs"))?
       }
 
       #[cfg(test)]
       {
         (String::from("127.0.0.1"), port)
-          .to_socket_addrs()?
-          .next()
-          .ok_or_else(|| anyhow!("failed to get socket addrs"))?
       }
-    };
+    }
+    .to_socket_addrs()?
+    .next()
+    .ok_or_else(|| anyhow!("failed to get socket addrs"))?;
 
     if !integration_test() {
       eprintln!(

--- a/src/subcommand/server.rs
+++ b/src/subcommand/server.rs
@@ -206,10 +206,23 @@ impl Server {
     port: u16,
     https_acceptor: Option<AxumAcceptor>,
   ) -> Result<task::JoinHandle<io::Result<()>>> {
-    let addr = (self.address.as_str(), port)
-      .to_socket_addrs()?
-      .next()
-      .ok_or_else(|| anyhow!("failed to get socket addrs"))?;
+    let addr = {
+      #[cfg(not(test))]
+      {
+        (self.address.as_str(), port)
+          .to_socket_addrs()?
+          .next()
+          .ok_or_else(|| anyhow!("failed to get socket addrs"))?
+      }
+
+      #[cfg(test)]
+      {
+        (String::from("127.0.0.1"), port)
+          .to_socket_addrs()?
+          .next()
+          .ok_or_else(|| anyhow!("failed to get socket addrs"))?
+      }
+    };
 
     if !integration_test() {
       eprintln!(


### PR DESCRIPTION
Just opened this to see if you know a better way of doing this. The `#[cfg(test)]` unfortunately does not work for integration tests: https://users.rust-lang.org/t/cfg-test-does-not-work-with-integration-tests/36630/5.

#1068 