### PR TITLE
Remove wrapping on text inscriptions

### DIFF
--- a/static/index.css
+++ b/static/index.css
@@ -222,5 +222,4 @@ iframe.inscription {
 
 pre.inscription {
   color: white;
-  white-space: pre-wrap;
 }


### PR DESCRIPTION
This improves the look of text without hard line wraps, but makes text with hard line wraps look much worse, so I think we should remove it.

We should encourage inscription authors to use HTML or markdown if they don't want hard line breaks. Since omitting all tags is allowed in html, you can publish just the text, no need for `<html>` or anything else.


# Before

<img width="799" alt="Screen Shot 2022-12-26 at 4 07 55 PM" src="https://user-images.githubusercontent.com/1945/209589739-dbd1b895-bf3e-497b-8cb5-a37685ced402.png">

# After

<img width="814" alt="Screen Shot 2022-12-26 at 4 13 25 PM" src="https://user-images.githubusercontent.com/1945/209589766-e2190ea0-ff3c-4664-ad87-1d14101e5ee7.png">
