### PR TITLE
Unrecognized even fields render inscriptions invalid

### DIFF
--- a/src/inscription.rs
+++ b/src/inscription.rs
@@ -219,7 +219,7 @@ impl<'a> InscriptionParser<'a> {
       let content_type = fields.remove(CONTENT_TYPE_TAG);
 
       for tag in fields.keys() {
-        if let Some(lsb) = tag.get(0) {
+        if let Some(lsb) = tag.first() {
           if lsb % 2 == 0 {
             return Err(InscriptionError::UnrecognizedEvenField);
           }

--- a/src/inscription.rs
+++ b/src/inscription.rs
@@ -119,10 +119,11 @@ impl Inscription {
 #[derive(Debug, PartialEq)]
 enum InscriptionError {
   EmptyWitness,
-  KeyPathSpend,
-  Script(script::Error),
-  NoInscription,
   InvalidInscription,
+  KeyPathSpend,
+  NoInscription,
+  Script(script::Error),
+  UnrecognizedEvenField,
 }
 
 type Result<T, E = InscriptionError> = std::result::Result<T, E>;
@@ -214,9 +215,20 @@ impl<'a> InscriptionParser<'a> {
         }
       }
 
+      let content = fields.remove(CONTENT_TAG);
+      let content_type = fields.remove(CONTENT_TYPE_TAG);
+
+      for tag in fields.keys() {
+        if let Some(lsb) = tag.get(0) {
+          if lsb % 2 == 0 {
+            return Err(InscriptionError::UnrecognizedEvenField);
+          }
+        }
+      }
+
       return Ok(Some(Inscription {
-        content: fields.remove(CONTENT_TAG),
-        content_type: fields.remove(CONTENT_TYPE_TAG),
+        content,
+        content_type,
       }));
     }
 
@@ -341,7 +353,7 @@ mod tests {
         b"ord",
         &[1],
         b"text/plain;charset=utf-8",
-        &[2],
+        &[3],
         b"bar",
         &[],
         b"ord",
@@ -538,25 +550,6 @@ mod tests {
   }
 
   #[test]
-  fn junk() {
-    assert_eq!(
-      InscriptionParser::parse(&container(&[
-        b"ord",
-        &[2],
-        &[1],
-        b"foo",
-        &[],
-        b"ord",
-        b"ord"
-      ])),
-      Ok(Inscription {
-        content_type: None,
-        content: None,
-      }),
-    );
-  }
-
-  #[test]
   fn extract_from_transaction() {
     let tx = Transaction {
       version: 0,
@@ -701,6 +694,25 @@ mod tests {
         content_type: None,
         content: None,
       }
+    );
+  }
+
+  #[test]
+  fn unknown_odd_fields_are_ignored() {
+    assert_eq!(
+      InscriptionParser::parse(&container(&[b"ord", &[3], &[0]])),
+      Ok(Inscription {
+        content_type: None,
+        content: None,
+      }),
+    );
+  }
+
+  #[test]
+  fn unknown_even_fields_are_invalid() {
+    assert_eq!(
+      InscriptionParser::parse(&container(&[b"ord", &[2], &[0]])),
+      Err(InscriptionError::UnrecognizedEvenField),
     );
   }
 }


### PR DESCRIPTION
Fixes #1046. This doesn't add a version, but allows us to add one in the future. We can add a version field with an even tag, which will render it invalid for old clients, allowing for future upgrades.