### PR TITLE
Add testnet first inscription height

### DIFF
--- a/src/chain.rs
+++ b/src/chain.rs
@@ -42,7 +42,7 @@ impl Chain {
       Self::Mainnet => 767430,
       Self::Regtest => 0,
       Self::Signet => 112402,
-      Self::Testnet => 0,
+      Self::Testnet => 2413343,
     }
   }
 


### PR DESCRIPTION
Made an inscription on testnet in [tx 0a1b4e4acf89686e4d012561014041bffd57a62254486f24cb5b0a216c04f102](https://mempool.space/testnet/tx/0a1b4e4acf89686e4d012561014041bffd57a62254486f24cb5b0a216c04f102), at height 2413343, so this PR updates `Chain::first_inscription_height`.