### PR TITLE
Fix install script targets

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -108,11 +108,9 @@ if [ -z ${target-} ]; then
   uname_target=`uname -m`-`uname -s`
 
   case $uname_target in
-    aarch64-Linux)     target=aarch64-unknown-linux-musl;;
-    arm64-Darwin)      target=aarch64-apple-darwin;;
-    x86_64-Darwin)     target=x86_64-apple-darwin;;
-    x86_64-Linux)      target=x86_64-unknown-linux-musl;;
-    x86_64-Windows_NT) target=x86_64-pc-windows-msvc;;
+    arm64-Darwin) target=aarch64-apple-darwin;;
+    x86_64-Darwin) target=x86_64-apple-darwin;;
+    x86_64-Linux) target=x86_64-unknown-linux-gnu;;
     *)
       err 'Could not determine target from output of `uname -m`-`uname -s`, please use `--target`:' $uname_target
     ;;


### PR DESCRIPTION
I copied this from just, and it needed modifications.

- Removed the windows target. It's broken in Just's install.sh, which indicates that the script has never been run on windows T_T
- Fixed x86 linux target