### PR TITLE
Fee-spent but unlost inscriptions

### DIFF
--- a/src/index.rs
+++ b/src/index.rs
@@ -798,6 +798,10 @@ mod tests {
       self.index.update().unwrap();
       blocks
     }
+
+    fn configurations() -> Vec<Context> {
+      vec![Context::with_args(""), Context::with_args("--index-sats")]
+    }
   }
 
   #[test]
@@ -1118,8 +1122,7 @@ mod tests {
 
   #[test]
   fn inscriptions_are_tracked_correctly() {
-    for args in ["", "--index-sats"] {
-      let context = Context::with_args(args);
+    for context in Context::configurations() {
       context.mine_blocks(1);
 
       let inscription_id = context.rpc_server.broadcast_tx(TransactionTemplate {
@@ -1146,8 +1149,7 @@ mod tests {
 
   #[test]
   fn unaligned_inscriptions_are_tracked_correctly() {
-    for args in ["", "--index-sats"] {
-      let context = Context::with_args(args);
+    for context in Context::configurations() {
       context.mine_blocks(1);
 
       let inscription_id = context.rpc_server.broadcast_tx(TransactionTemplate {
@@ -1193,8 +1195,7 @@ mod tests {
 
   #[test]
   fn merged_inscriptions_are_tracked_correctly() {
-    for args in ["", "--index-sats"] {
-      let context = Context::with_args(args);
+    for context in Context::configurations() {
       context.mine_blocks(2);
 
       let first_inscription_id = context.rpc_server.broadcast_tx(TransactionTemplate {
@@ -1246,8 +1247,7 @@ mod tests {
 
   #[test]
   fn inscriptions_that_are_sent_to_second_output_are_are_tracked_correctly() {
-    for args in ["", "--index-sats"] {
-      let context = Context::with_args(args);
+    for context in Context::configurations() {
       context.mine_blocks(1);
 
       let inscription_id = context.rpc_server.broadcast_tx(TransactionTemplate {
@@ -1344,8 +1344,7 @@ mod tests {
 
   #[test]
   fn fee_spent_inscriptions_are_tracked_correctly() {
-    for args in ["", "--index-sats"] {
-      let context = Context::with_args(args);
+    for context in Context::configurations() {
       context.mine_blocks(1);
 
       let inscription_id = context.rpc_server.broadcast_tx(TransactionTemplate {
@@ -1380,8 +1379,7 @@ mod tests {
 
   #[test]
   fn inscription_can_be_fee_spent_in_first_transaction() {
-    for args in ["", "--index-sats"] {
-      let context = Context::with_args(args);
+    for context in Context::configurations() {
       context.mine_blocks(1);
 
       let inscription_id = context.rpc_server.broadcast_tx(TransactionTemplate {
@@ -1409,8 +1407,7 @@ mod tests {
 
   #[test]
   fn lost_inscriptions() {
-    for args in ["", "--index-sats"] {
-      let context = Context::with_args(args);
+    for context in Context::configurations() {
       context.mine_blocks(1);
 
       let inscription_id = context.rpc_server.broadcast_tx(TransactionTemplate {
@@ -1435,8 +1432,7 @@ mod tests {
 
   #[test]
   fn multiple_inscriptions_can_be_lost() {
-    for args in ["", "--index-sats"] {
-      let context = Context::with_args(args);
+    for context in Context::configurations() {
       context.mine_blocks(1);
 
       let first_inscription_id = context.rpc_server.broadcast_tx(TransactionTemplate {
@@ -1507,8 +1503,7 @@ mod tests {
 
   #[test]
   fn lost_inscriptions_get_lost_satpoints() {
-    for args in ["", "--index-sats"] {
-      let context = Context::with_args(args);
+    for context in Context::configurations() {
       context.mine_blocks_with_subsidy(1, 0);
       context.mine_blocks(1);
 
@@ -1540,8 +1535,7 @@ mod tests {
 
   #[test]
   fn inscription_skips_zero_value_first_output_of_inscribe_transaction() {
-    for args in ["", "--index-sats"] {
-      let context = Context::with_args(args);
+    for context in Context::configurations() {
       context.mine_blocks(1);
 
       let inscription_id = context.rpc_server.broadcast_tx(TransactionTemplate {
@@ -1569,8 +1563,7 @@ mod tests {
 
   #[test]
   fn inscription_can_be_lost_in_first_transaction() {
-    for args in ["", "--index-sats"] {
-      let context = Context::with_args(args);
+    for context in Context::configurations() {
       context.mine_blocks(1);
 
       let inscription_id = context.rpc_server.broadcast_tx(TransactionTemplate {

--- a/src/index.rs
+++ b/src/index.rs
@@ -94,6 +94,7 @@ pub(crate) enum Statistic {
   OutputsTraversed = 0,
   Commits = 1,
   SatRanges = 2,
+  LostSats = 3,
 }
 
 impl Statistic {
@@ -247,7 +248,7 @@ impl Index {
     })
   }
 
-  pub(crate) fn has_satoshi_index(&self) -> Result<bool> {
+  pub(crate) fn has_sat_index(&self) -> Result<bool> {
     match self.begin_read()?.0.open_table(OUTPOINT_TO_SAT_RANGES) {
       Ok(_) => Ok(true),
       Err(redb::Error::TableDoesNotExist(_)) => Ok(false),
@@ -256,7 +257,7 @@ impl Index {
   }
 
   fn require_satoshi_index(&self, feature: &str) -> Result {
-    if !self.has_satoshi_index()? {
+    if !self.has_sat_index()? {
       bail!("{feature} requires index created with `--index-sats` flag")
     }
 
@@ -364,16 +365,17 @@ impl Index {
   }
 
   #[cfg(test)]
-  pub(crate) fn statistic(&self, statistic: Statistic) -> Result<u64> {
-    Ok(
-      self
-        .database
-        .begin_read()?
-        .open_table(STATISTIC_TO_COUNT)?
-        .get(&statistic.key())?
-        .map(|x| x.value())
-        .unwrap_or(0),
-    )
+  pub(crate) fn statistic(&self, statistic: Statistic) -> u64 {
+    self
+      .database
+      .begin_read()
+      .unwrap()
+      .open_table(STATISTIC_TO_COUNT)
+      .unwrap()
+      .get(&statistic.key())
+      .unwrap()
+      .map(|x| x.value())
+      .unwrap_or(0)
   }
 
   pub(crate) fn height(&self) -> Result<Option<Height>> {
@@ -401,7 +403,7 @@ impl Index {
   }
 
   pub(crate) fn rare_sat_satpoints(&self) -> Result<Option<Vec<(Sat, SatPoint)>>> {
-    if self.has_satoshi_index()? {
+    if self.has_sat_index()? {
       let mut result = Vec::new();
 
       let rtx = self.database.begin_read()?;
@@ -419,7 +421,7 @@ impl Index {
   }
 
   pub(crate) fn rare_sat_satpoint(&self, sat: Sat) -> Result<Option<SatPoint>> {
-    if self.has_satoshi_index()? {
+    if self.has_sat_index()? {
       Ok(
         self
           .database
@@ -671,7 +673,12 @@ impl Index {
   }
 
   #[cfg(test)]
-  fn assert_inscription_location(&self, inscription_id: InscriptionId, satpoint: SatPoint) {
+  fn assert_inscription_location(
+    &self,
+    inscription_id: InscriptionId,
+    satpoint: SatPoint,
+    sat: u64,
+  ) {
     let rtx = self.database.begin_read().unwrap();
 
     let satpoint_to_inscription_id = rtx.open_table(SATPOINT_TO_INSCRIPTION_ID).unwrap();
@@ -704,6 +711,34 @@ impl Index {
       ),
       inscription_id,
     );
+
+    if self.has_sat_index().unwrap() {
+      assert_eq!(
+        InscriptionId::from_inner(
+          *rtx
+            .open_table(SAT_TO_INSCRIPTION_ID)
+            .unwrap()
+            .get(&sat)
+            .unwrap()
+            .unwrap()
+            .value()
+        ),
+        inscription_id,
+      );
+
+      assert_eq!(
+        decode_satpoint(
+          *rtx
+            .open_table(SAT_TO_SATPOINT)
+            .unwrap()
+            .get(&sat)
+            .unwrap()
+            .unwrap()
+            .value()
+        ),
+        satpoint,
+      );
+    }
   }
 }
 
@@ -719,10 +754,6 @@ mod tests {
   }
 
   impl Context {
-    fn new() -> Self {
-      Self::with_args("")
-    }
-
     fn with_args(args: &str) -> Self {
       let rpc_server = test_bitcoincore_rpc::spawn();
 
@@ -756,8 +787,14 @@ mod tests {
       }
     }
 
-    fn mine_blocks(&self, num: u64) -> Vec<Block> {
-      let blocks = self.rpc_server.mine_blocks(num);
+    fn mine_blocks(&self, n: u64) -> Vec<Block> {
+      let blocks = self.rpc_server.mine_blocks(n);
+      self.index.update().unwrap();
+      blocks
+    }
+
+    fn mine_blocks_with_subsidy(&self, n: u64, subsidy: u64) -> Vec<Block> {
+      let blocks = self.rpc_server.mine_blocks_with_subsidy(n, subsidy);
       self.index.update().unwrap();
       blocks
     }
@@ -820,8 +857,8 @@ mod tests {
 
     context.mine_blocks(1);
     let split_coinbase_output = TransactionTemplate {
-      input_slots: &[(1, 0, 0)],
-      output_count: 2,
+      inputs: &[(1, 0, 0)],
+      outputs: 2,
       fee: 0,
       ..Default::default()
     };
@@ -846,8 +883,7 @@ mod tests {
 
     context.mine_blocks(2);
     let merge_coinbase_outputs = TransactionTemplate {
-      input_slots: &[(1, 0, 0), (2, 0, 0)],
-      output_count: 1,
+      inputs: &[(1, 0, 0), (2, 0, 0)],
       fee: 0,
       ..Default::default()
     };
@@ -870,8 +906,8 @@ mod tests {
 
     context.mine_blocks(1);
     let fee_paying_tx = TransactionTemplate {
-      input_slots: &[(1, 0, 0)],
-      output_count: 2,
+      inputs: &[(1, 0, 0)],
+      outputs: 2,
       fee: 10,
       ..Default::default()
     };
@@ -904,14 +940,12 @@ mod tests {
 
     context.mine_blocks(2);
     let first_fee_paying_tx = TransactionTemplate {
-      input_slots: &[(1, 0, 0)],
-      output_count: 1,
+      inputs: &[(1, 0, 0)],
       fee: 10,
       ..Default::default()
     };
     let second_fee_paying_tx = TransactionTemplate {
-      input_slots: &[(2, 0, 0)],
-      output_count: 1,
+      inputs: &[(2, 0, 0)],
       fee: 10,
       ..Default::default()
     };
@@ -940,8 +974,7 @@ mod tests {
 
     context.mine_blocks(1);
     let no_value_output = TransactionTemplate {
-      input_slots: &[(1, 0, 0)],
-      output_count: 1,
+      inputs: &[(1, 0, 0)],
       fee: 50 * COIN_VALUE,
       ..Default::default()
     };
@@ -960,8 +993,7 @@ mod tests {
 
     context.mine_blocks(1);
     let no_value_output = TransactionTemplate {
-      input_slots: &[(1, 0, 0)],
-      output_count: 1,
+      inputs: &[(1, 0, 0)],
       fee: 50 * COIN_VALUE,
       ..Default::default()
     };
@@ -969,8 +1001,7 @@ mod tests {
     context.mine_blocks(1);
 
     let no_value_input = TransactionTemplate {
-      input_slots: &[(2, 1, 0)],
-      output_count: 1,
+      inputs: &[(2, 1, 0)],
       fee: 0,
       ..Default::default()
     };
@@ -988,8 +1019,7 @@ mod tests {
     let context = Context::with_args("--index-sats");
     context.mine_blocks(1);
     context.rpc_server.broadcast_tx(TransactionTemplate {
-      input_slots: &[(1, 0, 0)],
-      output_count: 1,
+      inputs: &[(1, 0, 0)],
       fee: 0,
       ..Default::default()
     });
@@ -1072,8 +1102,7 @@ mod tests {
     let context = Context::with_args("--index-sats");
     context.mine_blocks(1);
     let spend_txid = context.rpc_server.broadcast_tx(TransactionTemplate {
-      input_slots: &[(1, 0, 0)],
-      output_count: 1,
+      inputs: &[(1, 0, 0)],
       fee: 0,
       ..Default::default()
     });
@@ -1088,192 +1117,507 @@ mod tests {
   }
 
   #[test]
+  fn inscriptions_are_tracked_correctly() {
+    for args in ["", "--index-sats"] {
+      let context = Context::with_args(args);
+      context.mine_blocks(1);
+
+      let inscription_id = context.rpc_server.broadcast_tx(TransactionTemplate {
+        inputs: &[(1, 0, 0)],
+        witness: inscription("text/plain", "hello").to_witness(),
+        ..Default::default()
+      });
+
+      context.mine_blocks(1);
+
+      context.index.assert_inscription_location(
+        inscription_id,
+        SatPoint {
+          outpoint: OutPoint {
+            txid: inscription_id,
+            vout: 0,
+          },
+          offset: 0,
+        },
+        50 * COIN_VALUE,
+      );
+    }
+  }
+
+  #[test]
   fn unaligned_inscriptions_are_tracked_correctly() {
-    let context = Context::new();
-    context.mine_blocks(1);
+    for args in ["", "--index-sats"] {
+      let context = Context::with_args(args);
+      context.mine_blocks(1);
 
-    let inscription = inscription("text/plain", "hello");
-    let inscription_id = context.rpc_server.broadcast_tx(TransactionTemplate {
-      input_slots: &[(1, 0, 0)],
-      output_count: 1,
-      fee: 0,
-      witness: inscription.to_witness(),
-    });
+      let inscription_id = context.rpc_server.broadcast_tx(TransactionTemplate {
+        inputs: &[(1, 0, 0)],
+        witness: inscription("text/plain", "hello").to_witness(),
+        ..Default::default()
+      });
 
-    context.mine_blocks(1);
+      context.mine_blocks(1);
 
-    context.index.assert_inscription_location(
-      inscription_id,
-      SatPoint {
-        outpoint: OutPoint {
-          txid: inscription_id,
-          vout: 0,
+      context.index.assert_inscription_location(
+        inscription_id,
+        SatPoint {
+          outpoint: OutPoint {
+            txid: inscription_id,
+            vout: 0,
+          },
+          offset: 0,
         },
-        offset: 0,
-      },
-    );
+        50 * COIN_VALUE,
+      );
 
-    let send_txid = context.rpc_server.broadcast_tx(TransactionTemplate {
-      input_slots: &[(2, 0, 0), (2, 1, 0)],
-      output_count: 1,
-      ..Default::default()
-    });
+      let send_txid = context.rpc_server.broadcast_tx(TransactionTemplate {
+        inputs: &[(2, 0, 0), (2, 1, 0)],
+        ..Default::default()
+      });
 
-    context.mine_blocks(1);
+      context.mine_blocks(1);
 
-    context.index.assert_inscription_location(
-      inscription_id,
-      SatPoint {
-        outpoint: OutPoint {
-          txid: send_txid,
-          vout: 0,
+      context.index.assert_inscription_location(
+        inscription_id,
+        SatPoint {
+          outpoint: OutPoint {
+            txid: send_txid,
+            vout: 0,
+          },
+          offset: 50 * COIN_VALUE,
         },
-        offset: 50 * COIN_VALUE,
-      },
-    );
+        50 * COIN_VALUE,
+      );
+    }
   }
 
   #[test]
   fn merged_inscriptions_are_tracked_correctly() {
-    let context = Context::new();
-    context.mine_blocks(2);
+    for args in ["", "--index-sats"] {
+      let context = Context::with_args(args);
+      context.mine_blocks(2);
 
-    let first_inscription = inscription("text/plain", "hello");
-    let first_inscription_id = context.rpc_server.broadcast_tx(TransactionTemplate {
-      input_slots: &[(1, 0, 0)],
-      output_count: 1,
-      fee: 0,
-      witness: first_inscription.to_witness(),
-    });
+      let first_inscription_id = context.rpc_server.broadcast_tx(TransactionTemplate {
+        inputs: &[(1, 0, 0)],
+        witness: inscription("text/plain", "hello").to_witness(),
+        ..Default::default()
+      });
 
-    let second_inscription = inscription("text/png", [1; 100]);
-    let second_inscription_id = context.rpc_server.broadcast_tx(TransactionTemplate {
-      input_slots: &[(2, 0, 0)],
-      output_count: 1,
-      fee: 0,
-      witness: second_inscription.to_witness(),
-    });
+      let second_inscription_id = context.rpc_server.broadcast_tx(TransactionTemplate {
+        inputs: &[(2, 0, 0)],
+        witness: inscription("text/png", [1; 100]).to_witness(),
+        ..Default::default()
+      });
 
-    context.mine_blocks(1);
+      context.mine_blocks(1);
 
-    let merged_txid = context.rpc_server.broadcast_tx(TransactionTemplate {
-      input_slots: &[(3, 1, 0), (3, 2, 0)],
-      output_count: 1,
-      ..Default::default()
-    });
+      let merged_txid = context.rpc_server.broadcast_tx(TransactionTemplate {
+        inputs: &[(3, 1, 0), (3, 2, 0)],
+        ..Default::default()
+      });
 
-    context.mine_blocks(1);
+      context.mine_blocks(1);
 
-    context.index.assert_inscription_location(
-      first_inscription_id,
-      SatPoint {
-        outpoint: OutPoint {
-          txid: merged_txid,
-          vout: 0,
+      context.index.assert_inscription_location(
+        first_inscription_id,
+        SatPoint {
+          outpoint: OutPoint {
+            txid: merged_txid,
+            vout: 0,
+          },
+          offset: 0,
         },
-        offset: 0,
-      },
-    );
+        50 * COIN_VALUE,
+      );
 
-    context.index.assert_inscription_location(
-      second_inscription_id,
-      SatPoint {
-        outpoint: OutPoint {
-          txid: merged_txid,
-          vout: 0,
+      context.index.assert_inscription_location(
+        second_inscription_id,
+        SatPoint {
+          outpoint: OutPoint {
+            txid: merged_txid,
+            vout: 0,
+          },
+          offset: 50 * COIN_VALUE,
         },
-        offset: 50 * COIN_VALUE,
-      },
-    );
+        100 * COIN_VALUE,
+      );
+    }
   }
 
   #[test]
   fn inscriptions_that_are_sent_to_second_output_are_are_tracked_correctly() {
-    let context = Context::new();
-    context.mine_blocks(1);
+    for args in ["", "--index-sats"] {
+      let context = Context::with_args(args);
+      context.mine_blocks(1);
 
-    let inscription = inscription("text/plain", "hello");
-    let inscription_id = context.rpc_server.broadcast_tx(TransactionTemplate {
-      input_slots: &[(1, 0, 0)],
-      output_count: 1,
-      fee: 0,
-      witness: inscription.to_witness(),
-    });
+      let inscription_id = context.rpc_server.broadcast_tx(TransactionTemplate {
+        inputs: &[(1, 0, 0)],
+        witness: inscription("text/plain", "hello").to_witness(),
+        ..Default::default()
+      });
 
-    context.mine_blocks(1);
+      context.mine_blocks(1);
 
-    context.index.assert_inscription_location(
-      inscription_id,
-      SatPoint {
-        outpoint: OutPoint {
-          txid: inscription_id,
-          vout: 0,
+      context.index.assert_inscription_location(
+        inscription_id,
+        SatPoint {
+          outpoint: OutPoint {
+            txid: inscription_id,
+            vout: 0,
+          },
+          offset: 0,
         },
-        offset: 0,
-      },
-    );
+        50 * COIN_VALUE,
+      );
 
-    let send_txid = context.rpc_server.broadcast_tx(TransactionTemplate {
-      input_slots: &[(2, 0, 0), (2, 1, 0)],
-      output_count: 2,
-      ..Default::default()
-    });
+      let send_txid = context.rpc_server.broadcast_tx(TransactionTemplate {
+        inputs: &[(2, 0, 0), (2, 1, 0)],
+        outputs: 2,
+        ..Default::default()
+      });
 
-    context.mine_blocks(1);
+      context.mine_blocks(1);
 
-    context.index.assert_inscription_location(
-      inscription_id,
-      SatPoint {
-        outpoint: OutPoint {
-          txid: send_txid,
-          vout: 1,
+      context.index.assert_inscription_location(
+        inscription_id,
+        SatPoint {
+          outpoint: OutPoint {
+            txid: send_txid,
+            vout: 1,
+          },
+          offset: 0,
         },
-        offset: 0,
-      },
-    );
+        50 * COIN_VALUE,
+      );
+    }
   }
 
   #[test]
   fn missing_inputs_are_fetched_from_bitcoin_core() {
-    let context = Context::with_args("--first-inscription-height 2");
-    context.mine_blocks(1);
+    for args in [
+      "--first-inscription-height 2",
+      "--first-inscription-height 2 --index-sats",
+    ] {
+      let context = Context::with_args(args);
+      context.mine_blocks(1);
 
-    let inscription = inscription("text/plain", "hello");
-    let inscription_id = context.rpc_server.broadcast_tx(TransactionTemplate {
-      input_slots: &[(1, 0, 0)],
-      output_count: 1,
-      fee: 0,
-      witness: inscription.to_witness(),
-    });
+      let inscription_id = context.rpc_server.broadcast_tx(TransactionTemplate {
+        inputs: &[(1, 0, 0)],
+        witness: inscription("text/plain", "hello").to_witness(),
+        ..Default::default()
+      });
 
-    context.mine_blocks(1);
+      context.mine_blocks(1);
 
-    context.index.assert_inscription_location(
-      inscription_id,
-      SatPoint {
-        outpoint: OutPoint {
-          txid: inscription_id,
-          vout: 0,
+      context.index.assert_inscription_location(
+        inscription_id,
+        SatPoint {
+          outpoint: OutPoint {
+            txid: inscription_id,
+            vout: 0,
+          },
+          offset: 0,
         },
+        50 * COIN_VALUE,
+      );
+
+      let send_txid = context.rpc_server.broadcast_tx(TransactionTemplate {
+        inputs: &[(2, 0, 0), (2, 1, 0)],
+        ..Default::default()
+      });
+
+      context.mine_blocks(1);
+
+      context.index.assert_inscription_location(
+        inscription_id,
+        SatPoint {
+          outpoint: OutPoint {
+            txid: send_txid,
+            vout: 0,
+          },
+          offset: 50 * COIN_VALUE,
+        },
+        50 * COIN_VALUE,
+      );
+    }
+  }
+
+  #[test]
+  fn fee_spent_inscriptions_are_tracked_correctly() {
+    for args in ["", "--index-sats"] {
+      let context = Context::with_args(args);
+      context.mine_blocks(1);
+
+      let inscription_id = context.rpc_server.broadcast_tx(TransactionTemplate {
+        inputs: &[(1, 0, 0)],
+        witness: inscription("text/plain", "hello").to_witness(),
+        ..Default::default()
+      });
+
+      context.mine_blocks(1);
+
+      context.rpc_server.broadcast_tx(TransactionTemplate {
+        inputs: &[(2, 1, 0)],
+        fee: 50 * COIN_VALUE,
+        ..Default::default()
+      });
+
+      let coinbase_tx = context.mine_blocks(1)[0].txdata[0].txid();
+
+      context.index.assert_inscription_location(
+        inscription_id,
+        SatPoint {
+          outpoint: OutPoint {
+            txid: coinbase_tx,
+            vout: 0,
+          },
+          offset: 50 * COIN_VALUE,
+        },
+        50 * COIN_VALUE,
+      );
+    }
+  }
+
+  #[test]
+  fn inscription_can_be_fee_spent_in_first_transaction() {
+    for args in ["", "--index-sats"] {
+      let context = Context::with_args(args);
+      context.mine_blocks(1);
+
+      let inscription_id = context.rpc_server.broadcast_tx(TransactionTemplate {
+        inputs: &[(1, 0, 0)],
+        fee: 50 * COIN_VALUE,
+        witness: inscription("text/plain", "hello").to_witness(),
+        ..Default::default()
+      });
+
+      let coinbase_tx = context.mine_blocks(1)[0].txdata[0].txid();
+
+      context.index.assert_inscription_location(
+        inscription_id,
+        SatPoint {
+          outpoint: OutPoint {
+            txid: coinbase_tx,
+            vout: 0,
+          },
+          offset: 50 * COIN_VALUE,
+        },
+        50 * COIN_VALUE,
+      );
+    }
+  }
+
+  #[test]
+  fn lost_inscriptions() {
+    for args in ["", "--index-sats"] {
+      let context = Context::with_args(args);
+      context.mine_blocks(1);
+
+      let inscription_id = context.rpc_server.broadcast_tx(TransactionTemplate {
+        inputs: &[(1, 0, 0)],
+        fee: 50 * COIN_VALUE,
+        witness: inscription("text/plain", "hello").to_witness(),
+        ..Default::default()
+      });
+
+      context.mine_blocks_with_subsidy(1, 0);
+
+      context.index.assert_inscription_location(
+        inscription_id,
+        SatPoint {
+          outpoint: OutPoint::null(),
+          offset: 0,
+        },
+        50 * COIN_VALUE,
+      );
+    }
+  }
+
+  #[test]
+  fn multiple_inscriptions_can_be_lost() {
+    for args in ["", "--index-sats"] {
+      let context = Context::with_args(args);
+      context.mine_blocks(1);
+
+      let first_inscription_id = context.rpc_server.broadcast_tx(TransactionTemplate {
+        inputs: &[(1, 0, 0)],
+        fee: 50 * COIN_VALUE,
+        witness: inscription("text/plain", "hello").to_witness(),
+        ..Default::default()
+      });
+
+      context.mine_blocks_with_subsidy(1, 0);
+      context.mine_blocks(1);
+
+      let second_inscription_id = context.rpc_server.broadcast_tx(TransactionTemplate {
+        inputs: &[(3, 0, 0)],
+        fee: 50 * COIN_VALUE,
+        witness: inscription("text/plain", "hello").to_witness(),
+        ..Default::default()
+      });
+
+      context.mine_blocks_with_subsidy(1, 0);
+
+      context.index.assert_inscription_location(
+        first_inscription_id,
+        SatPoint {
+          outpoint: OutPoint::null(),
+          offset: 0,
+        },
+        50 * COIN_VALUE,
+      );
+
+      context.index.assert_inscription_location(
+        second_inscription_id,
+        SatPoint {
+          outpoint: OutPoint::null(),
+          offset: 50 * COIN_VALUE,
+        },
+        150 * COIN_VALUE,
+      );
+    }
+  }
+
+  #[test]
+  fn lost_sats_are_tracked_correctly() {
+    let context = Context::with_args("--index-sats");
+    assert_eq!(context.index.statistic(Statistic::LostSats), 0);
+
+    context.mine_blocks(1);
+    assert_eq!(context.index.statistic(Statistic::LostSats), 0);
+
+    context.mine_blocks_with_subsidy(1, 0);
+    assert_eq!(
+      context.index.statistic(Statistic::LostSats),
+      50 * COIN_VALUE
+    );
+
+    context.mine_blocks_with_subsidy(1, 0);
+    assert_eq!(
+      context.index.statistic(Statistic::LostSats),
+      100 * COIN_VALUE
+    );
+
+    context.mine_blocks(1);
+    assert_eq!(
+      context.index.statistic(Statistic::LostSats),
+      100 * COIN_VALUE
+    );
+  }
+
+  #[test]
+  fn lost_inscriptions_get_lost_satpoints() {
+    for args in ["", "--index-sats"] {
+      let context = Context::with_args(args);
+      context.mine_blocks_with_subsidy(1, 0);
+      context.mine_blocks(1);
+
+      let inscription_id = context.rpc_server.broadcast_tx(TransactionTemplate {
+        inputs: &[(2, 0, 0)],
+        outputs: 2,
+        witness: inscription("text/plain", "hello").to_witness(),
+        ..Default::default()
+      });
+      context.mine_blocks(1);
+
+      context.rpc_server.broadcast_tx(TransactionTemplate {
+        inputs: &[(3, 1, 1), (3, 1, 0)],
+        fee: 50 * COIN_VALUE,
+        ..Default::default()
+      });
+      context.mine_blocks_with_subsidy(1, 0);
+
+      context.index.assert_inscription_location(
+        inscription_id,
+        SatPoint {
+          outpoint: OutPoint::null(),
+          offset: 75 * COIN_VALUE,
+        },
+        100 * COIN_VALUE,
+      );
+    }
+  }
+
+  #[test]
+  fn inscription_skips_zero_value_first_output_of_inscribe_transaction() {
+    for args in ["", "--index-sats"] {
+      let context = Context::with_args(args);
+      context.mine_blocks(1);
+
+      let inscription_id = context.rpc_server.broadcast_tx(TransactionTemplate {
+        inputs: &[(1, 0, 0)],
+        outputs: 2,
+        witness: inscription("text/plain", "hello").to_witness(),
+        output_values: &[0, 50 * COIN_VALUE],
+        ..Default::default()
+      });
+      context.mine_blocks(1);
+
+      context.index.assert_inscription_location(
+        inscription_id,
+        SatPoint {
+          outpoint: OutPoint {
+            txid: inscription_id,
+            vout: 1,
+          },
+          offset: 0,
+        },
+        50 * COIN_VALUE,
+      );
+    }
+  }
+
+  #[test]
+  fn inscription_can_be_lost_in_first_transaction() {
+    for args in ["", "--index-sats"] {
+      let context = Context::with_args(args);
+      context.mine_blocks(1);
+
+      let inscription_id = context.rpc_server.broadcast_tx(TransactionTemplate {
+        inputs: &[(1, 0, 0)],
+        fee: 50 * COIN_VALUE,
+        witness: inscription("text/plain", "hello").to_witness(),
+        ..Default::default()
+      });
+      context.mine_blocks_with_subsidy(1, 0);
+
+      context.index.assert_inscription_location(
+        inscription_id,
+        SatPoint {
+          outpoint: OutPoint::null(),
+          offset: 0,
+        },
+        50 * COIN_VALUE,
+      );
+    }
+  }
+
+  #[test]
+  fn lost_rare_sats_are_tracked() {
+    let context = Context::with_args("--index-sats");
+    context.mine_blocks_with_subsidy(1, 0);
+    context.mine_blocks_with_subsidy(1, 0);
+
+    assert_eq!(
+      context
+        .index
+        .rare_sat_satpoint(Sat(50 * COIN_VALUE))
+        .unwrap()
+        .unwrap(),
+      SatPoint {
+        outpoint: OutPoint::null(),
         offset: 0,
       },
     );
 
-    let send_txid = context.rpc_server.broadcast_tx(TransactionTemplate {
-      input_slots: &[(2, 0, 0), (2, 1, 0)],
-      output_count: 1,
-      ..Default::default()
-    });
-
-    context.mine_blocks(1);
-
-    context.index.assert_inscription_location(
-      inscription_id,
+    assert_eq!(
+      context
+        .index
+        .rare_sat_satpoint(Sat(100 * COIN_VALUE))
+        .unwrap()
+        .unwrap(),
       SatPoint {
-        outpoint: OutPoint {
-          txid: send_txid,
-          vout: 0,
-        },
+        outpoint: OutPoint::null(),
         offset: 50 * COIN_VALUE,
       },
     );

--- a/src/index/updater/inscription_updater.rs
+++ b/src/index/updater/inscription_updater.rs
@@ -1,68 +1,110 @@
 use super::*;
 
+pub(super) struct Flotsam {
+  inscription_id: InscriptionId,
+  offset: u64,
+  old_satpoint: Option<SatPoint>,
+}
+
 pub(super) struct InscriptionUpdater<'a, 'db, 'tx> {
-  pub(super) height: u64,
-  pub(super) id_to_height: &'a mut Table<'db, 'tx, &'tx InscriptionIdArray, u64>,
-  pub(super) id_to_satpoint: &'a mut Table<'db, 'tx, &'tx InscriptionIdArray, &'tx SatPointArray>,
-  pub(super) index: &'a Index,
-  pub(super) next_number: &'a mut u64,
-  pub(super) number_to_id: &'a mut Table<'db, 'tx, u64, &'tx InscriptionIdArray>,
-  pub(super) outpoint_to_value: &'a mut Table<'db, 'tx, &'tx OutPointArray, u64>,
-  pub(super) satpoint_to_id: &'a mut Table<'db, 'tx, &'tx SatPointArray, &'tx InscriptionIdArray>,
+  flotsam: Vec<Flotsam>,
+  height: u64,
+  id_to_height: &'a mut Table<'db, 'tx, &'tx InscriptionIdArray, u64>,
+  id_to_satpoint: &'a mut Table<'db, 'tx, &'tx InscriptionIdArray, &'tx SatPointArray>,
+  index: &'a Index,
+  lost_sats: u64,
+  next_number: u64,
+  number_to_id: &'a mut Table<'db, 'tx, u64, &'tx InscriptionIdArray>,
+  outpoint_to_value: &'a mut Table<'db, 'tx, &'tx OutPointArray, u64>,
+  reward: u64,
+  sat_to_inscription_id: &'a mut Table<'db, 'tx, u64, &'tx InscriptionIdArray>,
+  satpoint_to_id: &'a mut Table<'db, 'tx, &'tx SatPointArray, &'tx InscriptionIdArray>,
 }
 
 impl<'a, 'db, 'tx> InscriptionUpdater<'a, 'db, 'tx> {
+  pub(super) fn new(
+    height: u64,
+    id_to_height: &'a mut Table<'db, 'tx, &'tx InscriptionIdArray, u64>,
+    id_to_satpoint: &'a mut Table<'db, 'tx, &'tx InscriptionIdArray, &'tx SatPointArray>,
+    index: &'a Index,
+    lost_sats: u64,
+    number_to_id: &'a mut Table<'db, 'tx, u64, &'tx InscriptionIdArray>,
+    outpoint_to_value: &'a mut Table<'db, 'tx, &'tx OutPointArray, u64>,
+    sat_to_inscription_id: &'a mut Table<'db, 'tx, u64, &'tx InscriptionIdArray>,
+    satpoint_to_id: &'a mut Table<'db, 'tx, &'tx SatPointArray, &'tx InscriptionIdArray>,
+  ) -> Result<Self> {
+    let next_number = number_to_id
+      .iter()?
+      .rev()
+      .map(|(number, _id)| number.value() + 1)
+      .next()
+      .unwrap_or(0);
+
+    Ok(Self {
+      flotsam: Vec::new(),
+      height,
+      id_to_height,
+      id_to_satpoint,
+      index,
+      lost_sats,
+      next_number,
+      number_to_id,
+      outpoint_to_value,
+      reward: Height(height).subsidy(),
+      sat_to_inscription_id,
+      satpoint_to_id,
+    })
+  }
+
   pub(super) fn index_transaction_inscriptions(
     &mut self,
     tx: &Transaction,
     txid: Txid,
-  ) -> Result<bool> {
-    let inscribed = Inscription::from_transaction(tx).is_some();
+    input_sat_ranges: Option<&VecDeque<(u64, u64)>>,
+  ) -> Result<u64> {
+    let mut inscriptions = Vec::new();
 
-    if inscribed {
-      let satpoint = encode_satpoint(SatPoint {
-        outpoint: OutPoint { txid, vout: 0 },
+    if Inscription::from_transaction(tx).is_some() {
+      inscriptions.push(Flotsam {
+        inscription_id: txid,
         offset: 0,
+        old_satpoint: None,
       });
-
-      let inscription_id = txid.as_inner();
-
-      self.id_to_height.insert(inscription_id, &self.height)?;
-      self.id_to_satpoint.insert(inscription_id, &satpoint)?;
-      self.satpoint_to_id.insert(&satpoint, inscription_id)?;
-      self.number_to_id.insert(self.next_number, inscription_id)?;
-      *self.next_number += 1;
     };
 
-    let mut inscriptions: Vec<(u64, InscriptionIdArray, SatPointArray)> = Vec::new();
-
-    let mut offset = 0;
+    let mut input = 0;
     for tx_in in &tx.input {
-      let outpoint = tx_in.previous_output;
-      let start = encode_satpoint(SatPoint {
-        outpoint,
-        offset: 0,
-      });
+      if tx_in.previous_output.is_null() {
+        input += Height(self.height).subsidy();
+      } else {
+        let outpoint = tx_in.previous_output;
+        let start = encode_satpoint(SatPoint {
+          outpoint,
+          offset: 0,
+        });
 
-      let end = encode_satpoint(SatPoint {
-        outpoint,
-        offset: u64::MAX,
-      });
+        let end = encode_satpoint(SatPoint {
+          outpoint,
+          offset: u64::MAX,
+        });
 
-      for (old_satpoint, inscription_id) in self
-        .satpoint_to_id
-        .range(start..=end)?
-        .map(|(satpoint, id)| (*satpoint.value(), *id.value()))
-      {
-        inscriptions.push((
-          offset + decode_satpoint(old_satpoint).offset,
-          inscription_id,
-          old_satpoint,
-        ));
-      }
+        for (old_satpoint, inscription_id) in self
+          .satpoint_to_id
+          .range(start..=end)?
+          .map(|(satpoint, id)| (*satpoint.value(), *id.value()))
+        {
+          let old_satpoint = decode_satpoint(old_satpoint);
+          inscriptions.push(Flotsam {
+            offset: input + old_satpoint.offset,
+            inscription_id: InscriptionId::from_inner(inscription_id),
+            old_satpoint: Some(old_satpoint),
+          });
+        }
+        self
+          .outpoint_to_value
+          .remove(&encode_outpoint(tx_in.previous_output))?;
 
-      if !tx_in.previous_output.is_null() {
-        offset += if let Some(value) = self
+        input += if let Some(value) = self
           .outpoint_to_value
           .get(&encode_outpoint(tx_in.previous_output))?
         {
@@ -81,40 +123,44 @@ impl<'a, 'db, 'tx> InscriptionUpdater<'a, 'db, 'tx> {
           .value
         }
       }
-
-      self
-        .outpoint_to_value
-        .remove(&encode_outpoint(tx_in.previous_output))?;
     }
 
-    inscriptions.sort();
+    let is_coinbase = tx
+      .input
+      .first()
+      .map(|tx_in| tx_in.previous_output.is_null())
+      .unwrap_or_default();
+
+    if is_coinbase {
+      inscriptions.append(&mut self.flotsam);
+    }
+
+    inscriptions.sort_by_key(|flotsam| flotsam.offset);
     let mut inscriptions = inscriptions.into_iter().peekable();
 
-    let mut start = 0;
+    let mut output = 0;
     for (vout, tx_out) in tx.output.iter().enumerate() {
-      let end = start + tx_out.value;
+      let end = output + tx_out.value;
 
-      while let Some((offset, inscription_id, old_satpoint)) = inscriptions.peek() {
-        if *offset >= end {
+      while let Some(flotsam) = inscriptions.peek() {
+        if flotsam.offset >= end {
           break;
         }
 
-        let new_satpoint = encode_satpoint(SatPoint {
+        let new_satpoint = SatPoint {
           outpoint: OutPoint {
             txid,
             vout: vout.try_into().unwrap(),
           },
-          offset: offset - start,
-        });
+          offset: flotsam.offset - output,
+        };
 
-        self.satpoint_to_id.remove(&old_satpoint)?;
-        self.satpoint_to_id.insert(&new_satpoint, &inscription_id)?;
-        self.id_to_satpoint.insert(&inscription_id, &new_satpoint)?;
+        self.update_inscription_location(input_sat_ranges, flotsam, new_satpoint)?;
 
         inscriptions.next();
       }
 
-      start = end;
+      output = end;
     }
 
     for (vout, tx_out) in tx.output.iter().enumerate() {
@@ -127,6 +173,67 @@ impl<'a, 'db, 'tx> InscriptionUpdater<'a, 'db, 'tx> {
       )?;
     }
 
-    Ok(inscribed)
+    if is_coinbase {
+      for flotsam in inscriptions {
+        let new_satpoint = SatPoint {
+          outpoint: OutPoint::null(),
+          offset: self.lost_sats + flotsam.offset - output,
+        };
+        self.update_inscription_location(input_sat_ranges, &flotsam, new_satpoint)?;
+      }
+
+      Ok(self.reward - output)
+    } else {
+      self.flotsam.extend(inscriptions.map(|flotsam| Flotsam {
+        offset: self.reward + flotsam.offset,
+        ..flotsam
+      }));
+      self.reward += input - output;
+      Ok(0)
+    }
+  }
+
+  fn update_inscription_location(
+    &mut self,
+    input_sat_ranges: Option<&VecDeque<(u64, u64)>>,
+    flotsam: &Flotsam,
+    new_satpoint: SatPoint,
+  ) -> Result {
+    let inscription_id = flotsam.inscription_id.into_inner();
+
+    match flotsam.old_satpoint {
+      Some(old_satpoint) => {
+        self.satpoint_to_id.remove(&encode_satpoint(old_satpoint))?;
+      }
+      None => {
+        self.id_to_height.insert(&inscription_id, &self.height)?;
+        self
+          .number_to_id
+          .insert(&self.next_number, &inscription_id)?;
+
+        if let Some(input_sat_ranges) = input_sat_ranges {
+          let mut offset = 0;
+          for (start, end) in input_sat_ranges {
+            let size = end - start;
+            if offset + size > flotsam.offset {
+              self
+                .sat_to_inscription_id
+                .insert(&(start + flotsam.offset - offset), &inscription_id)?;
+              break;
+            }
+            offset += size;
+          }
+        }
+
+        self.next_number += 1;
+      }
+    }
+
+    let new_satpoint = encode_satpoint(new_satpoint);
+
+    self.satpoint_to_id.insert(&new_satpoint, &inscription_id)?;
+    self.id_to_satpoint.insert(&inscription_id, &new_satpoint)?;
+
+    Ok(())
   }
 }

--- a/src/subcommand/server.rs
+++ b/src/subcommand/server.rs
@@ -338,10 +338,7 @@ impl Server {
           ))
         })?,
       }
-      .page(
-        chain,
-        index.has_satoshi_index().map_err(ServerError::Internal)?,
-      ),
+      .page(chain, index.has_sat_index().map_err(ServerError::Internal)?),
     )
   }
 
@@ -366,7 +363,7 @@ impl Server {
     Ok(
       OutputHtml {
         outpoint,
-        list: if index.has_satoshi_index().map_err(ServerError::Internal)? {
+        list: if index.has_sat_index().map_err(ServerError::Internal)? {
           Some(
             index
               .list(outpoint)
@@ -379,10 +376,7 @@ impl Server {
         chain,
         output,
       }
-      .page(
-        chain,
-        index.has_satoshi_index().map_err(ServerError::Internal)?,
-      ),
+      .page(chain, index.has_sat_index().map_err(ServerError::Internal)?),
     )
   }
 
@@ -399,10 +393,9 @@ impl Server {
       Ordering::Greater => Err(ServerError::BadRequest(
         "range start greater than range end".to_string(),
       )),
-      Ordering::Less => Ok(RangeHtml { start, end }.page(
-        chain,
-        index.has_satoshi_index().map_err(ServerError::Internal)?,
-      )),
+      Ordering::Less => Ok(
+        RangeHtml { start, end }.page(chain, index.has_sat_index().map_err(ServerError::Internal)?),
+      ),
     }
   }
 
@@ -432,10 +425,7 @@ impl Server {
           .get_latest_inscriptions(8)
           .map_err(|err| ServerError::Internal(anyhow!("error getting inscriptions: {err}")))?,
       )
-      .page(
-        chain,
-        index.has_satoshi_index().map_err(ServerError::Internal)?,
-      ),
+      .page(chain, index.has_sat_index().map_err(ServerError::Internal)?),
     )
   }
 
@@ -485,10 +475,8 @@ impl Server {
     };
 
     Ok(
-      BlockHtml::new(block, Height(height), Self::index_height(&index)?).page(
-        chain,
-        index.has_satoshi_index().map_err(ServerError::Internal)?,
-      ),
+      BlockHtml::new(block, Height(height), Self::index_height(&index)?)
+        .page(chain, index.has_sat_index().map_err(ServerError::Internal)?),
     )
   }
 
@@ -519,10 +507,7 @@ impl Server {
         inscription,
         chain,
       )
-      .page(
-        chain,
-        index.has_satoshi_index().map_err(ServerError::Internal)?,
-      ),
+      .page(chain, index.has_sat_index().map_err(ServerError::Internal)?),
     )
   }
 
@@ -640,10 +625,7 @@ impl Server {
       .nth(path.2)
       .ok_or_else(not_found)?;
 
-    Ok(InputHtml { path, input }.page(
-      chain,
-      index.has_satoshi_index().map_err(ServerError::Internal)?,
-    ))
+    Ok(InputHtml { path, input }.page(chain, index.has_sat_index().map_err(ServerError::Internal)?))
   }
 
   async fn faq() -> Redirect {
@@ -726,10 +708,7 @@ impl Server {
         inscription,
         satpoint,
       }
-      .page(
-        chain,
-        index.has_satoshi_index().map_err(ServerError::Internal)?,
-      ),
+      .page(chain, index.has_sat_index().map_err(ServerError::Internal)?),
     )
   }
 
@@ -743,10 +722,7 @@ impl Server {
           .get_latest_inscriptions(100)
           .map_err(|err| ServerError::Internal(anyhow!("error getting inscriptions: {err}")))?,
       }
-      .page(
-        chain,
-        index.has_satoshi_index().map_err(ServerError::Internal)?,
-      ),
+      .page(chain, index.has_sat_index().map_err(ServerError::Internal)?),
     )
   }
 }
@@ -804,7 +780,7 @@ mod tests {
         thread::spawn(|| server.run(options, index, ord_server_handle).unwrap());
       }
 
-      while index.statistic(crate::index::Statistic::Commits).unwrap() == 0 {
+      while index.statistic(crate::index::Statistic::Commits) == 0 {
         thread::sleep(Duration::from_millis(25));
       }
 
@@ -1383,8 +1359,7 @@ mod tests {
 
     test_server.bitcoin_rpc_server.mine_blocks(1);
     let transaction = TransactionTemplate {
-      input_slots: &[(1, 0, 0)],
-      output_count: 1,
+      inputs: &[(1, 0, 0)],
       fee: 0,
       ..Default::default()
     };
@@ -1549,13 +1524,7 @@ next.*",
   fn commits_are_tracked() {
     let server = TestServer::new();
 
-    assert_eq!(
-      server
-        .index
-        .statistic(crate::index::Statistic::Commits)
-        .unwrap(),
-      1
-    );
+    assert_eq!(server.index.statistic(crate::index::Statistic::Commits), 1);
 
     let info = server.index.info().unwrap();
     assert_eq!(info.transactions.len(), 1);
@@ -1563,13 +1532,7 @@ next.*",
 
     server.index.update().unwrap();
 
-    assert_eq!(
-      server
-        .index
-        .statistic(crate::index::Statistic::Commits)
-        .unwrap(),
-      1
-    );
+    assert_eq!(server.index.statistic(crate::index::Statistic::Commits), 1);
 
     let info = server.index.info().unwrap();
     assert_eq!(info.transactions.len(), 1);
@@ -1580,13 +1543,7 @@ next.*",
     thread::sleep(Duration::from_millis(10));
     server.index.update().unwrap();
 
-    assert_eq!(
-      server
-        .index
-        .statistic(crate::index::Statistic::Commits)
-        .unwrap(),
-      2
-    );
+    assert_eq!(server.index.statistic(crate::index::Statistic::Commits), 2);
 
     let info = server.index.info().unwrap();
     assert_eq!(info.transactions.len(), 2);
@@ -1604,8 +1561,7 @@ next.*",
     assert_eq!(
       server
         .index
-        .statistic(crate::index::Statistic::OutputsTraversed)
-        .unwrap(),
+        .statistic(crate::index::Statistic::OutputsTraversed),
       1
     );
 
@@ -1614,8 +1570,7 @@ next.*",
     assert_eq!(
       server
         .index
-        .statistic(crate::index::Statistic::OutputsTraversed)
-        .unwrap(),
+        .statistic(crate::index::Statistic::OutputsTraversed),
       1
     );
 
@@ -1627,8 +1582,7 @@ next.*",
     assert_eq!(
       server
         .index
-        .statistic(crate::index::Statistic::OutputsTraversed)
-        .unwrap(),
+        .statistic(crate::index::Statistic::OutputsTraversed),
       3
     );
   }
@@ -1638,10 +1592,7 @@ next.*",
     let server = TestServer::new_with_args(&["--index-sats"]);
 
     assert_eq!(
-      server
-        .index
-        .statistic(crate::index::Statistic::SatRanges)
-        .unwrap(),
+      server.index.statistic(crate::index::Statistic::SatRanges),
       1
     );
 
@@ -1649,10 +1600,7 @@ next.*",
     server.index.update().unwrap();
 
     assert_eq!(
-      server
-        .index
-        .statistic(crate::index::Statistic::SatRanges)
-        .unwrap(),
+      server.index.statistic(crate::index::Statistic::SatRanges),
       2
     );
 
@@ -1660,10 +1608,7 @@ next.*",
     server.index.update().unwrap();
 
     assert_eq!(
-      server
-        .index
-        .statistic(crate::index::Statistic::SatRanges)
-        .unwrap(),
+      server.index.statistic(crate::index::Statistic::SatRanges),
       3
     );
   }
@@ -1673,17 +1618,14 @@ next.*",
     let server = TestServer::new_with_args(&["--index-sats"]);
 
     assert_eq!(
-      server
-        .index
-        .statistic(crate::index::Statistic::SatRanges)
-        .unwrap(),
+      server.index.statistic(crate::index::Statistic::SatRanges),
       1
     );
 
     server.bitcoin_rpc_server.mine_blocks(1);
     server.bitcoin_rpc_server.broadcast_tx(TransactionTemplate {
-      input_slots: &[(1, 0, 0)],
-      output_count: 2,
+      inputs: &[(1, 0, 0)],
+      outputs: 2,
       fee: 0,
       ..Default::default()
     });
@@ -1691,10 +1633,7 @@ next.*",
     server.index.update().unwrap();
 
     assert_eq!(
-      server
-        .index
-        .statistic(crate::index::Statistic::SatRanges)
-        .unwrap(),
+      server.index.statistic(crate::index::Statistic::SatRanges),
       4,
     );
   }
@@ -1704,17 +1643,14 @@ next.*",
     let server = TestServer::new_with_args(&["--index-sats"]);
 
     assert_eq!(
-      server
-        .index
-        .statistic(crate::index::Statistic::SatRanges)
-        .unwrap(),
+      server.index.statistic(crate::index::Statistic::SatRanges),
       1
     );
 
     server.bitcoin_rpc_server.mine_blocks(1);
     server.bitcoin_rpc_server.broadcast_tx(TransactionTemplate {
-      input_slots: &[(1, 0, 0)],
-      output_count: 2,
+      inputs: &[(1, 0, 0)],
+      outputs: 2,
       fee: 2,
       ..Default::default()
     });
@@ -1722,10 +1658,7 @@ next.*",
     server.index.update().unwrap();
 
     assert_eq!(
-      server
-        .index
-        .statistic(crate::index::Statistic::SatRanges)
-        .unwrap(),
+      server.index.statistic(crate::index::Statistic::SatRanges),
       5,
     );
   }

--- a/test-bitcoincore-rpc/src/lib.rs
+++ b/test-bitcoincore-rpc/src/lib.rs
@@ -73,12 +73,24 @@ pub fn spawn() -> Handle {
   spawn_with(Network::Bitcoin, "ord")
 }
 
-#[derive(Default)]
 pub struct TransactionTemplate<'a> {
-  pub input_slots: &'a [(usize, usize, usize)],
-  pub output_count: usize,
   pub fee: u64,
+  pub inputs: &'a [(usize, usize, usize)],
+  pub output_values: &'a [u64],
+  pub outputs: usize,
   pub witness: Witness,
+}
+
+impl<'a> Default for TransactionTemplate<'a> {
+  fn default() -> Self {
+    Self {
+      fee: 0,
+      inputs: &[],
+      output_values: &[],
+      outputs: 1,
+      witness: Witness::default(),
+    }
+  }
 }
 
 pub struct Handle {
@@ -100,22 +112,19 @@ impl Handle {
     self.state().wallets.clone()
   }
 
-  pub fn mine_blocks(&self, num: u64) -> Vec<Block> {
-    let mut bitcoin_rpc_data = self.state.lock().unwrap();
-    (0..num)
-      .map(|_| bitcoin_rpc_data.push_block(50 * COIN_VALUE))
-      .collect()
+  pub fn mine_blocks(&self, n: u64) -> Vec<Block> {
+    self.mine_blocks_with_subsidy(n, 50 * COIN_VALUE)
   }
 
-  pub fn mine_blocks_with_subsidy(&self, num: u64, subsidy: u64) -> Vec<Block> {
+  pub fn mine_blocks_with_subsidy(&self, n: u64, subsidy: u64) -> Vec<Block> {
     let mut bitcoin_rpc_data = self.state.lock().unwrap();
-    (0..num)
+    (0..n)
       .map(|_| bitcoin_rpc_data.push_block(subsidy))
       .collect()
   }
 
-  pub fn broadcast_tx(&self, options: TransactionTemplate) -> Txid {
-    self.state().broadcast_tx(options)
+  pub fn broadcast_tx(&self, template: TransactionTemplate) -> Txid {
+    self.state().broadcast_tx(template)
   }
 
   pub fn invalidate_tip(&self) -> BlockHash {

--- a/test-bitcoincore-rpc/src/state.rs
+++ b/test-bitcoincore-rpc/src/state.rs
@@ -120,10 +120,10 @@ impl State {
     blockhash
   }
 
-  pub(crate) fn broadcast_tx(&mut self, options: TransactionTemplate) -> Txid {
+  pub(crate) fn broadcast_tx(&mut self, template: TransactionTemplate) -> Txid {
     let mut total_value = 0;
     let mut input = Vec::new();
-    for (i, (height, tx, vout)) in options.input_slots.iter().enumerate() {
+    for (i, (height, tx, vout)) in template.inputs.iter().enumerate() {
       let tx = &self.blocks.get(&self.hashes[*height]).unwrap().txdata[*tx];
       total_value += tx.output[*vout].value;
       input.push(TxIn {
@@ -131,16 +131,16 @@ impl State {
         script_sig: Script::new(),
         sequence: Sequence::MAX,
         witness: if i == 0 {
-          options.witness.clone()
+          template.witness.clone()
         } else {
           Witness::new()
         },
       });
     }
 
-    let value_per_output = (total_value - options.fee) / options.output_count as u64;
+    let value_per_output = (total_value - template.fee) / template.outputs as u64;
     assert_eq!(
-      value_per_output * options.output_count as u64 + options.fee,
+      value_per_output * template.outputs as u64 + template.fee,
       total_value
     );
 
@@ -148,9 +148,13 @@ impl State {
       version: 0,
       lock_time: PackedLockTime(0),
       input,
-      output: (0..options.output_count)
-        .map(|_| TxOut {
-          value: value_per_output,
+      output: (0..template.outputs)
+        .map(|i| TxOut {
+          value: template
+            .output_values
+            .get(i)
+            .cloned()
+            .unwrap_or(value_per_output),
           script_pubkey: script::Builder::new().into_script(),
         })
         .collect(),


### PR DESCRIPTION
@raphjaph This is a truly horrific PR, but I wrote a bunch of tests and tested it from a few angles and I think it works.

This does a few things:
- Tracks inscriptions that are spent to fees
- Tracks inscriptions that are spent to fees that are then underpaid (thus destroying the sat). These have their locations updated to a satpoint consisting of a null outpoint, with an offset which increments as sats are lost
- Tracks rare sats that are spent to fees