### PR TITLE
Fix limit max

### DIFF
--- a/src/subcommand/wallet/transactions.rs
+++ b/src/subcommand/wallet/transactions.rs
@@ -3,14 +3,14 @@ use super::*;
 #[derive(Debug, Parser)]
 pub(crate) struct Transactions {
   #[clap(long, help = "Fetch at most <LIMIT> transactions.")]
-  limit: Option<usize>,
+  limit: Option<u16>,
 }
 
 impl Transactions {
   pub(crate) fn run(self, options: Options) -> Result {
     for tx in options.bitcoin_rpc_client()?.list_transactions(
       None,
-      Some(self.limit.unwrap_or(u16::MAX as usize)),
+      Some(self.limit.unwrap_or(u16::MAX).into()),
       None,
       None,
     )? {

--- a/src/subcommand/wallet/transactions.rs
+++ b/src/subcommand/wallet/transactions.rs
@@ -10,7 +10,7 @@ impl Transactions {
   pub(crate) fn run(self, options: Options) -> Result {
     for tx in options.bitcoin_rpc_client()?.list_transactions(
       None,
-      Some(self.limit.unwrap_or(usize::MAX)),
+      Some(self.limit.unwrap_or(u16::MAX as usize)),
       None,
       None,
     )? {

--- a/test-bitcoincore-rpc/src/api.rs
+++ b/test-bitcoincore-rpc/src/api.rs
@@ -112,7 +112,7 @@ pub trait Api {
   fn list_transactions(
     &self,
     label: Option<String>,
-    count: Option<usize>,
+    count: Option<u16>,
     skip: Option<usize>,
     include_watchonly: Option<bool>,
   ) -> Result<Vec<ListTransactionResult>, jsonrpc_core::Error>;

--- a/test-bitcoincore-rpc/src/server.rs
+++ b/test-bitcoincore-rpc/src/server.rs
@@ -414,7 +414,7 @@ impl Api for Server {
   fn list_transactions(
     &self,
     _label: Option<String>,
-    count: Option<usize>,
+    count: Option<u16>,
     _skip: Option<usize>,
     _include_watchonly: Option<bool>,
   ) -> Result<Vec<ListTransactionResult>, jsonrpc_core::Error> {
@@ -423,7 +423,7 @@ impl Api for Server {
       state
         .transactions
         .iter()
-        .take(count.unwrap_or(usize::MAX))
+        .take(count.unwrap_or(u16::MAX).into())
         .map(|(txid, tx)| (*txid, tx))
         .chain(state.mempool.iter().map(|tx| (tx.txid(), tx)))
         .map(|(txid, tx)| ListTransactionResult {


### PR DESCRIPTION
This was failing when run against an actual Bitcoin Core node. I'm not sure what the real limit is, but u16::MAX seems to be okay, and u32::MAX failed, so I used a u16.