### PR TITLE
Fix thumbnail links

### DIFF
--- a/src/templates/home.rs
+++ b/src/templates/home.rs
@@ -53,7 +53,7 @@ mod tests {
       )
       .to_string(),
       "<h2>Latest Inscriptions</h2>
-<div class=inscriptions>
+<div class=thumbnails>
   <a href=/inscription/1{64}><iframe .* src=/preview/1{64}></iframe></a>
   <a href=/inscription/2{64}><iframe .* src=/preview/2{64}></iframe></a>
 </div>

--- a/src/templates/iframe.rs
+++ b/src/templates/iframe.rs
@@ -2,38 +2,38 @@ use super::*;
 
 pub(crate) struct Iframe {
   inscription_id: InscriptionId,
-  main: bool,
+  thumbnail: bool,
 }
 
 impl Iframe {
-  pub(crate) fn preview(inscription_id: InscriptionId) -> Trusted<Self> {
+  pub(crate) fn thumbnail(inscription_id: InscriptionId) -> Trusted<Self> {
     Trusted(Self {
       inscription_id,
-      main: false,
+      thumbnail: true,
     })
   }
 
   pub(crate) fn main(inscription_id: InscriptionId) -> Trusted<Self> {
     Trusted(Self {
       inscription_id,
-      main: true,
+      thumbnail: false,
     })
   }
 }
 
 impl Display for Iframe {
   fn fmt(&self, f: &mut Formatter) -> fmt::Result {
-    if self.main {
+    if self.thumbnail {
       write!(
         f,
-        "<a href=/preview/{}><iframe sandbox=allow-scripts scrolling=no src=/preview/{}></iframe></a>",
+        "<a href=/inscription/{}><iframe sandbox=allow-scripts scrolling=no src=/preview/{}></iframe></a>",
         self.inscription_id,
         self.inscription_id,
       )
     } else {
       write!(
         f,
-        "<a href=/inscription/{}><iframe sandbox=allow-scripts scrolling=no src=/preview/{}></iframe></a>",
+        "<a href=/preview/{}><iframe sandbox=allow-scripts scrolling=no src=/preview/{}></iframe></a>",
         self.inscription_id,
         self.inscription_id,
       )
@@ -48,7 +48,7 @@ mod tests {
   #[test]
   fn preview() {
     assert_regex_match!(
-      Iframe::preview(txid(1))
+      Iframe::thumbnail(txid(1))
       .0.to_string(),
       "<a href=/inscription/1{64}><iframe sandbox=allow-scripts scrolling=no src=/preview/1{64}></iframe></a>",
     );

--- a/src/templates/inscriptions.rs
+++ b/src/templates/inscriptions.rs
@@ -23,7 +23,7 @@ mod tests {
       },
       "
         <h1>Inscriptions</h1>
-        <div class=inscriptions>
+        <div class=thumbnails>
           <a href=/inscription/1{64}><iframe .* src=/preview/1{64}></iframe></a>
           <a href=/inscription/2{64}><iframe .* src=/preview/2{64}></iframe></a>
         </div>

--- a/src/templates/output.rs
+++ b/src/templates/output.rs
@@ -110,4 +110,35 @@ mod tests {
       .unindent()
     );
   }
+
+  #[test]
+  fn with_inscriptions() {
+    assert_regex_match!(
+      OutputHtml {
+        inscriptions: vec![txid(1)],
+        outpoint: "4a5e1e4baab89f3a32518a88c31bc87f618f76673e2cc77ab2127b7afdeda33b:0"
+          .parse()
+          .unwrap(),
+        list: None,
+        chain: Chain::Mainnet,
+        output: TxOut {
+          value: 3,
+          script_pubkey: Script::new_p2pkh(&PubkeyHash::all_zeros()),
+        },
+      },
+      "
+        <h1>Output <span class=monospace>4a5e1e4baab89f3a32518a88c31bc87f618f76673e2cc77ab2127b7afdeda33b:0</span></h1>
+        <dl>
+          <dt>inscriptions</dt>
+          <dd class=thumbnails>
+            <a href=/inscription/1{64}><iframe .* src=/preview/1{64}></iframe></a>
+          </dd>
+          <dt>value</dt><dd>3</dd>
+          <dt>script pubkey</dt><dd class=data>OP_DUP OP_HASH160 OP_PUSHBYTES_20 0000000000000000000000000000000000000000 OP_EQUALVERIFY OP_CHECKSIG</dd>
+          <dt>address</dt><dd class=monospace>1111111111111111111114oLvT2</dd>
+        </dl>
+      "
+      .unindent()
+    );
+  }
 }

--- a/src/templates/sat.rs
+++ b/src/templates/sat.rs
@@ -102,13 +102,9 @@ mod tests {
         sat: Sat(0),
         satpoint: None,
         blocktime: Blocktime::Confirmed(0),
-        inscription: Some(
-          "1111111111111111111111111111111111111111111111111111111111111111"
-            .parse()
-            .unwrap(),
-        ),
+        inscription: Some(txid(1)),
       },
-      r"<h1>Sat 0</h1>.*<dt>inscription</dt><dd><a href=/inscription/1{64}>.*</a></dd>.*",
+      r"<h1>Sat 0</h1>.*<dt>inscription</dt><dd class=thumbnails><a href=/inscription/1{64}>.*</a></dd>.*",
     );
   }
 

--- a/static/index.css
+++ b/static/index.css
@@ -213,7 +213,3 @@ a.mythic {
 .inscription > a > iframe {
   width: 100%;
 }
-
-a.thumbnail {
-  display: block;
-}

--- a/static/index.css
+++ b/static/index.css
@@ -168,19 +168,19 @@ a.mythic {
   color: var(--mythic);
 }
 
-.inscriptions {
+.thumbnails {
   display: flex;
   flex-wrap: wrap;
 }
 
-.inscriptions > a {
+.thumbnails > a {
   border-radius: 2%;
   margin: 1%;
   overflow: hidden;
   width: 23%;
 }
 
-.inscriptions iframe {
+.thumbnails iframe {
   height: 101%;
   overflow: hidden;
   width: 101%;
@@ -212,4 +212,8 @@ a.mythic {
 
 .inscription > a > iframe {
   width: 100%;
+}
+
+a.thumbnail {
+  display: block;
 }

--- a/templates/home.html
+++ b/templates/home.html
@@ -1,8 +1,8 @@
 %% if !&self.inscriptions.is_empty() {
 <h2>Latest Inscriptions</h2>
-<div class=inscriptions>
+<div class=thumbnails>
 %% for id in &self.inscriptions {
-  {{Iframe::preview(*id)}}
+  {{Iframe::thumbnail(*id)}}
 %% }
 </div>
 <div class=center><a href=/inscriptions>more…</a></div>

--- a/templates/inscriptions.html
+++ b/templates/inscriptions.html
@@ -1,6 +1,6 @@
 <h1>Inscriptions</h1>
-<div class=inscriptions>
+<div class=thumbnails>
 %% for id in &self.inscriptions {
-  {{Iframe::preview(*id)}}
+  {{Iframe::thumbnail(*id)}}
 %% }
 </div>

--- a/templates/output.html
+++ b/templates/output.html
@@ -2,9 +2,11 @@
 <dl>
 %% if !self.inscriptions.is_empty() {
   <dt>inscriptions</dt>
+  <dd class=thumbnails>
 %% for inscription in &self.inscriptions {
-  <dd>{{Iframe::preview(*inscription)}}</dd>
+    {{Iframe::thumbnail(*inscription)}}
 %% }
+  </dd>
 %% }
   <dt>value</dt><dd>{{ self.output.value }}</dd>
   <dt>script pubkey</dt><dd class=data>{{ self.output.script_pubkey.asm() }}</dd>

--- a/templates/sat.html
+++ b/templates/sat.html
@@ -12,7 +12,7 @@
   <dt>rarity</dt><dd><span class={{self.sat.rarity()}}>{{ self.sat.rarity() }}</span></dd>
   <dt>time</dt><dd>{{ self.blocktime }}</dd>
 %% if let Some((inscription)) = &self.inscription {
-  <dt>inscription</dt><dd>{{ Iframe::preview(*inscription) }}</dd>
+  <dt>inscription</dt><dd class=thumbnails>{{ Iframe::thumbnail(*inscription) }}</dd>
 %% }
 %% if let Some(satpoint) = self.satpoint {
   <dt>location</dt><dd class=monospace>{{ satpoint }}</dd>

--- a/templates/transaction.html
+++ b/templates/transaction.html
@@ -1,7 +1,9 @@
 <h1>Transaction <span class=monospace>{{self.txid}}</span></h1>
 %% if let Some(inscription) = &self.inscription {
 <h2>Inscription Geneses</h2>
-{{ Iframe::preview(self.txid) }}
+<div class=thumbnails>
+{{ Iframe::thumbnail(self.txid) }}
+</div>
 %% }
 <h2>{{"Output".tally(self.transaction.output.len())}}</h2>
 <ul class=monospace>

--- a/tests/server.rs
+++ b/tests/server.rs
@@ -214,7 +214,7 @@ fn home_page_includes_latest_inscriptions() {
     "/",
     format!(
       ".*<h2>Latest Inscriptions</h2>
-<div class=inscriptions>
+<div class=thumbnails>
   <a href=/inscription/{inscription_id}><iframe .*></a>
 </div>.*"
     ),
@@ -237,7 +237,7 @@ fn home_page_inscriptions_are_sorted() {
     "/",
     format!(
       ".*<h2>Latest Inscriptions</h2>
-<div class=inscriptions>{inscriptions}
+<div class=thumbnails>{inscriptions}
 </div>.*"
     ),
   );
@@ -264,7 +264,7 @@ fn inscriptions_page() {
     "/inscriptions",
     format!(
       ".*<h1>Inscriptions</h1>
-<div class=inscriptions>
+<div class=thumbnails>
   <a href=/inscription/{reveal_tx}>.*</a>
 </div>
 .*",


### PR DESCRIPTION
Fixes #1194.

Changes the `inscriptions` class to `thumbnails`, to be more descriptive, and uses it wherever we're displaying inscriptions. Makes links on output pages clickable.