### PR TITLE
Don't check lockfile on CI

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -12,6 +12,9 @@ defaults:
   run:
     shell: bash
 
+env:
+  RUSTFLAGS: --deny warnings
+
 jobs:
   docs:
     runs-on: ubuntu-latest
@@ -43,9 +46,6 @@ jobs:
   lint:
     runs-on: ubuntu-latest
 
-    env:
-      RUSTFLAGS: --deny warnings
-
     steps:
     - uses: actions/checkout@v3
 
@@ -57,9 +57,6 @@ jobs:
         toolchain: stable
 
     - uses: Swatinem/rust-cache@v2
-
-    - name: Check Lockfile
-      run: cargo update --locked --package ord
 
     - name: Clippy
       run: cargo clippy --all --all-targets
@@ -80,9 +77,6 @@ jobs:
         - windows-latest
 
     runs-on: ${{matrix.os}}
-
-    env:
-      RUSTFLAGS: --deny warnings
 
     steps:
     - uses: actions/checkout@v3


### PR DESCRIPTION
It's not a very important check, so we can just skip it on CI.