### PR TITLE
Remove HTTP to HTTPS redirect implementation in favor of HAProxy

### DIFF
--- a/deploy/haproxy.cfg
+++ b/deploy/haproxy.cfg
@@ -1,0 +1,4 @@
+frontend ord
+  mode http
+  bind :80
+  http-request redirect scheme https

--- a/deploy/ord.service
+++ b/deploy/ord.service
@@ -15,9 +15,7 @@ ExecStart=/usr/local/bin/ord \
   --index-sats \
   server \
   --acme-contact mailto:casey@rodarmor.com \
-  --http \
-  --https \
-  --redirect-http-to-https
+  --https
 Group=ord
 MemoryDenyWriteExecute=true
 NoNewPrivileges=true

--- a/deploy/setup
+++ b/deploy/setup
@@ -22,6 +22,7 @@ hostnamectl set-hostname $DOMAIN
 apt-get install --yes \
   acl \
   clang \
+  haproxy \
   libsqlite3-dev\
   libssl-dev \
   pkg-config \
@@ -53,6 +54,14 @@ case $CHAIN in
 esac
 
 ufw --force enable
+
+if [[ ! -f /etc/haproxy/haproxy-original.cfg ]]; then
+  cp /etc/haproxy/{haproxy,haproxy-original}.cfg
+fi
+
+cat /etc/haproxy/haproxy-original.cfg deploy/haproxy.cfg > /etc/haproxy/haproxy.cfg
+
+systemctl reload haproxy
 
 if ! which bitcoind; then
   wget -O bitcoin.tar.gz 'https://bitcoincore.org/bin/bitcoin-core-23.0/bitcoin-23.0-x86_64-linux-gnu.tar.gz'


### PR DESCRIPTION
Eventually we can remove Let's Encrypt support entirely, but that's a more complicated configuration, so this is a good start.