### PR TITLE
Empty preview

### DIFF
--- a/src/inscription.rs
+++ b/src/inscription.rs
@@ -87,8 +87,16 @@ impl Inscription {
     self.append_reveal_script_to_builder(builder).into_script()
   }
 
-  pub(crate) fn media(&self) -> Option<Media> {
-    self.content_type()?.parse().ok()
+  pub(crate) fn media(&self) -> Media {
+    if self.content.is_none() {
+      return Media::Unknown;
+    }
+
+    let Some(content_type) = self.content_type() else {
+      return Media::Unknown;
+    };
+
+    content_type.parse().unwrap_or(Media::Unknown)
   }
 
   pub(crate) fn content_bytes(&self) -> Option<&[u8]> {

--- a/src/inscription.rs
+++ b/src/inscription.rs
@@ -13,22 +13,19 @@ use {
 
 const PROTOCOL_ID: &[u8] = b"ord";
 
-const CONTENT_TAG: &[u8] = &[];
+const BODY_TAG: &[u8] = &[];
 const CONTENT_TYPE_TAG: &[u8] = &[1];
 
 #[derive(Debug, PartialEq, Clone)]
 pub(crate) struct Inscription {
-  content: Option<Vec<u8>>,
+  body: Option<Vec<u8>>,
   content_type: Option<Vec<u8>>,
 }
 
 impl Inscription {
   #[cfg(test)]
-  pub(crate) fn new(content_type: Option<Vec<u8>>, content: Option<Vec<u8>>) -> Self {
-    Self {
-      content_type,
-      content,
-    }
+  pub(crate) fn new(content_type: Option<Vec<u8>>, body: Option<Vec<u8>>) -> Self {
+    Self { content_type, body }
   }
 
   pub(crate) fn from_transaction(tx: &Transaction) -> Option<Inscription> {
@@ -38,10 +35,10 @@ impl Inscription {
   pub(crate) fn from_file(chain: Chain, path: impl AsRef<Path>) -> Result<Self, Error> {
     let path = path.as_ref();
 
-    let content = fs::read(path).with_context(|| format!("io error reading {}", path.display()))?;
+    let body = fs::read(path).with_context(|| format!("io error reading {}", path.display()))?;
 
     if let Some(limit) = chain.inscription_content_size_limit() {
-      let len = content.len();
+      let len = body.len();
       if len > limit {
         bail!("content size of {len} bytes exceeds {limit} byte limit for {chain} inscriptions");
       }
@@ -56,7 +53,7 @@ impl Inscription {
     )?;
 
     Ok(Self {
-      content: Some(content),
+      body: Some(body),
       content_type: Some(content_type.into()),
     })
   }
@@ -73,9 +70,9 @@ impl Inscription {
         .push_slice(content_type);
     }
 
-    if let Some(content) = &self.content {
-      builder = builder.push_slice(CONTENT_TAG);
-      for chunk in content.chunks(520) {
+    if let Some(body) = &self.body {
+      builder = builder.push_slice(BODY_TAG);
+      for chunk in body.chunks(520) {
         builder = builder.push_slice(chunk);
       }
     }
@@ -88,7 +85,7 @@ impl Inscription {
   }
 
   pub(crate) fn media(&self) -> Media {
-    if self.content.is_none() {
+    if self.body.is_none() {
       return Media::Unknown;
     }
 
@@ -99,16 +96,16 @@ impl Inscription {
     content_type.parse().unwrap_or(Media::Unknown)
   }
 
-  pub(crate) fn content_bytes(&self) -> Option<&[u8]> {
-    Some(self.content.as_ref()?)
+  pub(crate) fn body(&self) -> Option<&[u8]> {
+    Some(self.body.as_ref()?)
   }
 
-  pub(crate) fn into_content(self) -> Option<Vec<u8>> {
-    self.content
+  pub(crate) fn into_body(self) -> Option<Vec<u8>> {
+    self.body
   }
 
-  pub(crate) fn content_size(&self) -> Option<usize> {
-    Some(self.content_bytes()?.len())
+  pub(crate) fn content_length(&self) -> Option<usize> {
+    Some(self.body()?.len())
   }
 
   pub(crate) fn content_type(&self) -> Option<&str> {
@@ -210,12 +207,12 @@ impl<'a> InscriptionParser<'a> {
 
       loop {
         match self.advance()? {
-          Instruction::PushBytes(CONTENT_TAG) => {
-            let mut content = Vec::new();
+          Instruction::PushBytes(BODY_TAG) => {
+            let mut body = Vec::new();
             while !self.accept(Instruction::Op(opcodes::all::OP_ENDIF))? {
-              content.extend_from_slice(self.expect_push()?);
+              body.extend_from_slice(self.expect_push()?);
             }
-            fields.insert(CONTENT_TAG, content);
+            fields.insert(BODY_TAG, body);
             break;
           }
           Instruction::PushBytes(tag) => {
@@ -229,7 +226,7 @@ impl<'a> InscriptionParser<'a> {
         }
       }
 
-      let content = fields.remove(CONTENT_TAG);
+      let body = fields.remove(BODY_TAG);
       let content_type = fields.remove(CONTENT_TYPE_TAG);
 
       for tag in fields.keys() {
@@ -240,10 +237,7 @@ impl<'a> InscriptionParser<'a> {
         }
       }
 
-      return Ok(Some(Inscription {
-        content,
-        content_type,
-      }));
+      return Ok(Some(Inscription { body, content_type }));
     }
 
     Ok(None)
@@ -385,7 +379,7 @@ mod tests {
       InscriptionParser::parse(&envelope(&[b"ord", &[1], b"text/plain;charset=utf-8"])),
       Ok(Inscription {
         content_type: Some(b"text/plain;charset=utf-8".to_vec()),
-        content: None,
+        body: None,
       }),
     );
   }
@@ -396,13 +390,13 @@ mod tests {
       InscriptionParser::parse(&envelope(&[b"ord", &[], b"foo"])),
       Ok(Inscription {
         content_type: None,
-        content: Some(b"foo".to_vec()),
+        body: Some(b"foo".to_vec()),
       }),
     );
   }
 
   #[test]
-  fn valid_content_in_multiple_pushes() {
+  fn valid_body_in_multiple_pushes() {
     assert_eq!(
       InscriptionParser::parse(&envelope(&[
         b"ord",
@@ -417,7 +411,7 @@ mod tests {
   }
 
   #[test]
-  fn valid_content_in_zero_pushes() {
+  fn valid_body_in_zero_pushes() {
     assert_eq!(
       InscriptionParser::parse(&envelope(&[b"ord", &[1], b"text/plain;charset=utf-8", &[]])),
       Ok(inscription("text/plain;charset=utf-8", "")),
@@ -425,7 +419,7 @@ mod tests {
   }
 
   #[test]
-  fn valid_content_in_multiple_empty_pushes() {
+  fn valid_body_in_multiple_empty_pushes() {
     assert_eq!(
       InscriptionParser::parse(&envelope(&[
         b"ord",
@@ -552,7 +546,7 @@ mod tests {
   }
 
   #[test]
-  fn no_content() {
+  fn empty_envelope() {
     assert_eq!(
       InscriptionParser::parse(&envelope(&[])),
       Err(InscriptionError::NoInscription)
@@ -718,7 +712,7 @@ mod tests {
     witness.push(
       &Inscription {
         content_type: None,
-        content: None,
+        body: None,
       }
       .append_reveal_script(script::Builder::new()),
     );
@@ -729,7 +723,7 @@ mod tests {
       InscriptionParser::parse(&witness).unwrap(),
       Inscription {
         content_type: None,
-        content: None,
+        body: None,
       }
     );
   }
@@ -740,7 +734,7 @@ mod tests {
       InscriptionParser::parse(&envelope(&[b"ord", &[3], &[0]])),
       Ok(Inscription {
         content_type: None,
-        content: None,
+        body: None,
       }),
     );
   }

--- a/src/media.rs
+++ b/src/media.rs
@@ -6,6 +6,7 @@ pub(crate) enum Media {
   Iframe,
   Image,
   Text,
+  Unknown,
 }
 
 impl Media {

--- a/src/subcommand/server.rs
+++ b/src/subcommand/server.rs
@@ -696,7 +696,7 @@ impl Server {
       HeaderValue::from_static("default-src 'unsafe-eval' 'unsafe-inline'"),
     );
 
-    Some((headers, inscription.into_content()?))
+    Some((headers, inscription.into_body()?))
   }
 
   async fn preview(
@@ -726,7 +726,7 @@ impl Server {
       ),
       Media::Text => {
         let content = inscription
-          .content_bytes()
+          .body()
           .ok_or_not_found(|| format!("inscription {inscription_id} content"))?;
 
         Ok(

--- a/src/subcommand/server.rs
+++ b/src/subcommand/server.rs
@@ -2052,4 +2052,27 @@ mod tests {
       ".*<title>Inscription 0</title>.*",
     );
   }
+
+  #[test]
+  fn inscription_with_no_body_has_unknonwn_preview() {
+    let server = TestServer::new_with_sat_index();
+    server.mine_blocks(1);
+
+    let txid = server.bitcoin_rpc_server.broadcast_tx(TransactionTemplate {
+      inputs: &[(1, 0, 0)],
+      witness: Inscription::new(Some("text/plain;charset=utf-8".as_bytes().to_vec()), None)
+        .to_witness(),
+      ..Default::default()
+    });
+
+    let inscription_id = InscriptionId::from(txid);
+
+    server.mine_blocks(1);
+
+    server.assert_response_regex(
+      format!("/preview/{}", inscription_id),
+      StatusCode::OK,
+      ".*<title>Inscription 0</title>.*",
+    );
+  }
 }

--- a/src/subcommand/server.rs
+++ b/src/subcommand/server.rs
@@ -707,13 +707,9 @@ impl Server {
       .get_inscription_by_id(inscription_id)?
       .ok_or_not_found(|| format!("inscription {inscription_id}"))?;
 
-    let content = inscription
-      .content_bytes()
-      .ok_or_not_found(|| format!("inscription {inscription_id} content"))?;
-
     return match inscription.media() {
-      Some(Media::Audio) => Ok(PreviewAudioHtml { inscription_id }.into_response()),
-      Some(Media::Image) => Ok(
+      Media::Audio => Ok(PreviewAudioHtml { inscription_id }.into_response()),
+      Media::Image => Ok(
         (
           [(
             header::CONTENT_SECURITY_POLICY,
@@ -723,18 +719,25 @@ impl Server {
         )
           .into_response(),
       ),
-      Some(Media::Iframe) => Ok(
+      Media::Iframe => Ok(
         Self::content_response(inscription)
           .ok_or_not_found(|| format!("inscription {inscription_id} content"))?
           .into_response(),
       ),
-      Some(Media::Text) => Ok(
-        PreviewTextHtml {
-          text: str::from_utf8(content).map_err(|err| anyhow!("Failed to decode UTF-8: {err}"))?,
-        }
-        .into_response(),
-      ),
-      None => Ok(PreviewUnknownHtml.into_response()),
+      Media::Text => {
+        let content = inscription
+          .content_bytes()
+          .ok_or_not_found(|| format!("inscription {inscription_id} content"))?;
+
+        Ok(
+          PreviewTextHtml {
+            text: str::from_utf8(content)
+              .map_err(|err| anyhow!("Failed to decode UTF-8: {err}"))?,
+          }
+          .into_response(),
+        )
+      }
+      Media::Unknown => Ok(PreviewUnknownHtml.into_response()),
     };
   }
 
@@ -2054,14 +2057,13 @@ mod tests {
   }
 
   #[test]
-  fn inscription_with_no_body_has_unknonwn_preview() {
+  fn inscription_with_unknown_type_and_no_body_has_unknown_preview() {
     let server = TestServer::new_with_sat_index();
     server.mine_blocks(1);
 
     let txid = server.bitcoin_rpc_server.broadcast_tx(TransactionTemplate {
       inputs: &[(1, 0, 0)],
-      witness: Inscription::new(Some("text/plain;charset=utf-8".as_bytes().to_vec()), None)
-        .to_witness(),
+      witness: Inscription::new(Some("foo/bar".as_bytes().to_vec()), None).to_witness(),
       ..Default::default()
     });
 
@@ -2069,10 +2071,32 @@ mod tests {
 
     server.mine_blocks(1);
 
-    server.assert_response_regex(
+    server.assert_response(
       format!("/preview/{}", inscription_id),
       StatusCode::OK,
-      ".*<title>Inscription 0</title>.*",
+      &fs::read_to_string("templates/preview-unknown.html").unwrap(),
+    );
+  }
+
+  #[test]
+  fn inscription_with_known_type_and_no_body_has_unknown_preview() {
+    let server = TestServer::new_with_sat_index();
+    server.mine_blocks(1);
+
+    let txid = server.bitcoin_rpc_server.broadcast_tx(TransactionTemplate {
+      inputs: &[(1, 0, 0)],
+      witness: Inscription::new(Some("image/png".as_bytes().to_vec()), None).to_witness(),
+      ..Default::default()
+    });
+
+    let inscription_id = InscriptionId::from(txid);
+
+    server.mine_blocks(1);
+
+    server.assert_response(
+      format!("/preview/{}", inscription_id),
+      StatusCode::OK,
+      &fs::read_to_string("templates/preview-unknown.html").unwrap(),
     );
   }
 }

--- a/src/templates/inscription.rs
+++ b/src/templates/inscription.rs
@@ -61,7 +61,7 @@ mod tests {
           <dd>1</dd>
           <dt>content</dt>
           <dd><a href=/content/1{64}i1>link</a></dd>
-          <dt>content size</dt>
+          <dt>content length</dt>
           <dd>10 bytes</dd>
           <dt>content type</dt>
           <dd>text/plain;charset=utf-8</dd>

--- a/src/test.rs
+++ b/src/test.rs
@@ -100,8 +100,8 @@ pub(crate) fn tx_out(value: u64, address: Address) -> TxOut {
   }
 }
 
-pub(crate) fn inscription(content_type: &str, content: impl AsRef<[u8]>) -> Inscription {
-  Inscription::new(Some(content_type.into()), Some(content.as_ref().into()))
+pub(crate) fn inscription(content_type: &str, body: impl AsRef<[u8]>) -> Inscription {
+  Inscription::new(Some(content_type.into()), Some(body.as_ref().into()))
 }
 
 pub(crate) fn inscription_id(n: u32) -> InscriptionId {

--- a/templates/inscription.html
+++ b/templates/inscription.html
@@ -25,11 +25,11 @@
   <dt>sat</dt>
   <dd><a href=/sat/{{sat}}>{{sat}}</a></dd>
 %% }
-%% if let Some(content_size) = self.inscription.content_size() {
+%% if let Some(content_length) = self.inscription.content_length() {
   <dt>content</dt>
   <dd><a href=/content/{{self.inscription_id}}>link</a></dd>
-  <dt>content size</dt>
-  <dd>{{ content_size }} bytes</dd>
+  <dt>content length</dt>
+  <dd>{{ content_length }} bytes</dd>
 %% }
 %% if let Some(content_type) = self.inscription.content_type() {
   <dt>content type</dt>

--- a/tests/server.rs
+++ b/tests/server.rs
@@ -60,7 +60,7 @@ fn inscription_page() {
   <dd>10000</dd>
   <dt>content</dt>
   <dd><a href=/content/{inscription}>link</a></dd>
-  <dt>content size</dt>
+  <dt>content length</dt>
   <dd>3 bytes</dd>
   <dt>content type</dt>
   <dd>text/plain;charset=utf-8</dd>

--- a/tests/wallet/send.rs
+++ b/tests/wallet/send.rs
@@ -29,7 +29,7 @@ fn inscriptions_can_be_sent() {
     format!("/inscription/{inscription}"),
     format!(
       ".*<h1>Inscription 0</h1>.*<dl>.*
-  <dt>content size</dt>
+  <dt>content length</dt>
   <dd>3 bytes</dd>
   <dt>content type</dt>
   <dd>text/plain;charset=utf-8</dd>


### PR DESCRIPTION
This fixes an issue where old inscriptions on signet with no body had previews containing error messages.

Changes the `media` function to return `Media::Unknown` if:

- There is no body, since trying to preview an inscription with no body would return a 404.
- The content type is unknown or otherwise invalid, since we don't know what it is.

`/content` will still return a 404 for an inscription with no body.