### PR TITLE
Display newest thumbnails on right

### DIFF
--- a/static/index.css
+++ b/static/index.css
@@ -170,6 +170,7 @@ a.mythic {
 
 .thumbnails {
   display: flex;
+  flex-direction: row-reverse;
   flex-wrap: wrap;
 }
 


### PR DESCRIPTION
Display thumbnails oldest on the left, newest on the right. This makes left/right order consistent with navigation keys.