### PR TITLE
Make genesis clock mark orange and add tooltip to height

### DIFF
--- a/templates/clock.svg
+++ b/templates/clock.svg
@@ -9,10 +9,6 @@
       stroke: gold;
     }
 
-    .mythic:hover {
-      stroke: #f2a900;
-    }
-
     text:hover {
       fill-opacity: 1;
     }
@@ -30,8 +26,8 @@
     }
   </style>
   <circle r="19" stroke-width="0.2"/>
-  <text y="4" dominant-baseline="middle" text-anchor="middle" stroke="none" fill="lightgrey" fill-opacity="0" font-size="4" font-family="sans-serif">{{self.height}}</text>
-  <a href="/sat/0°0′0″0‴"><line class="mythic" y1="-16" y2="-15" stroke-width="0.3" stroke="#d00505"><title>Genesis</title></line></a>
+  <text y="4" dominant-baseline="middle" text-anchor="middle" stroke="none" fill="lightgrey" fill-opacity="0" font-size="4" font-family="sans-serif"><title>Height</title>{{self.height}}</text>
+  <a href="/sat/0°0′0″0‴"><line class="mythic" y1="-16" y2="-15" stroke-width="0.3" stroke="#f2a900"><title>Genesis</title></line></a>
   <a href="/sat/0°0′336″0‴"><line class="epic" y1="-16" y2="-15" stroke-width="0.3" transform="rotate(10.90909090909091)"><title>1st Halving</title></line></a>
   <a href="/sat/0°0′672″0‴"><line class="epic" y1="-16" y2="-15" stroke-width="0.3" transform="rotate(21.81818181818182)"><title>2nd Halving</title></line></a>
   <a href="/sat/0°0′1008″0‴"><line class="epic" y1="-16" y2="-15" stroke-width="0.3" transform="rotate(32.72727272727273)"><title>3rd Halving</title></line></a>


### PR DESCRIPTION
If the genesis mark is red, it looks like it's related to the red second hand. Make the genesis mark always orange, not just on hover. Also add a tooltip to the height.