### PR TITLE
Un-reverse thumbnail row order

### DIFF
--- a/static/index.css
+++ b/static/index.css
@@ -170,6 +170,7 @@ a.mythic {
 
 .thumbnails {
   display: flex;
+  flex-direction: row-reverse;
   flex-wrap: wrap;
 }
 

--- a/static/index.css
+++ b/static/index.css
@@ -170,7 +170,6 @@ a.mythic {
 
 .thumbnails {
   display: flex;
-  flex-direction: row-reverse;
   flex-wrap: wrap;
 }
 


### PR DESCRIPTION
Fixes #1320. I did this so that left and right arrows would be consistent with thumbnail order, but @haribosan thought it was confusing, and I'm inclined to agree, so let's revert it.