### PR TITLE
Allow single tapping nav arrows on iOS Safari

### DIFF
--- a/static/index.css
+++ b/static/index.css
@@ -194,18 +194,17 @@ a.mythic {
 }
 
 .inscription > *:nth-child(1), .inscription > *:nth-child(3) {
-  color: var(--dark-fg);
+  color: var(--dark-bg);
   flex: 1;
   font-size: 200%;
   text-decoration: none;
   display: flex;
   justify-content: center;
   align-items: center;
-  opacity: 0;
 }
 
 .inscription > a:nth-child(1):hover, .inscription > a:nth-child(3):hover {
-  opacity: 1;
+  color: var(--dark-fg);
 }
 
 .inscription > *:nth-child(2) {


### PR DESCRIPTION
The inscription nav arrows on iOS Safari require two taps to activate. This seems to be related to opacity 0, so I changed it to use the color to hide the arrows instead. This now allows them to be activated in a single tap on Safari.