### PR TITLE
Improve timestamps

### DIFF
--- a/src/blocktime.rs
+++ b/src/blocktime.rs
@@ -2,12 +2,20 @@ use super::*;
 
 #[derive(Copy, Clone)]
 pub(crate) enum Blocktime {
-  Confirmed(i64),
-  Expected(i64),
+  Confirmed(DateTime<Utc>),
+  Expected(DateTime<Utc>),
 }
 
 impl Blocktime {
-  fn timestamp(self) -> i64 {
+  pub(crate) fn confirmed(seconds: u32) -> Self {
+    Self::Confirmed(timestamp(seconds))
+  }
+
+  pub(crate) fn expected(seconds: u32) -> Self {
+    Self::Expected(timestamp(seconds))
+  }
+
+  fn timestamp(self) -> DateTime<Utc> {
     match self {
       Self::Confirmed(timestamp) | Self::Expected(timestamp) => timestamp,
     }
@@ -16,11 +24,7 @@ impl Blocktime {
 
 impl Display for Blocktime {
   fn fmt(&self, f: &mut Formatter) -> fmt::Result {
-    write!(
-      f,
-      "{}",
-      NaiveDateTime::from_timestamp_opt(self.timestamp(), 0).unwrap()
-    )?;
+    write!(f, "{}", self.timestamp())?;
 
     if let Self::Expected(_) = self {
       write!(f, " (expected)")?;
@@ -36,10 +40,13 @@ mod tests {
 
   #[test]
   fn display() {
-    assert_eq!(Blocktime::Confirmed(0).to_string(), "1970-01-01 00:00:00");
     assert_eq!(
-      Blocktime::Expected(0).to_string(),
-      "1970-01-01 00:00:00 (expected)"
+      Blocktime::confirmed(0).to_string(),
+      "1970-01-01 00:00:00 UTC"
+    );
+    assert_eq!(
+      Blocktime::expected(0).to_string(),
+      "1970-01-01 00:00:00 UTC (expected)"
     );
   }
 }

--- a/src/blocktime.rs
+++ b/src/blocktime.rs
@@ -11,10 +11,6 @@ impl Blocktime {
     Self::Confirmed(timestamp(seconds))
   }
 
-  pub(crate) fn expected(seconds: u32) -> Self {
-    Self::Expected(timestamp(seconds))
-  }
-
   fn timestamp(self) -> DateTime<Utc> {
     match self {
       Self::Confirmed(timestamp) | Self::Expected(timestamp) => timestamp,
@@ -45,7 +41,7 @@ mod tests {
       "1970-01-01 00:00:00 UTC"
     );
     assert_eq!(
-      Blocktime::expected(0).to_string(),
+      Blocktime::Expected(timestamp(0)).to_string(),
       "1970-01-01 00:00:00 UTC (expected)"
     );
   }

--- a/src/blocktime.rs
+++ b/src/blocktime.rs
@@ -11,38 +11,16 @@ impl Blocktime {
     Self::Confirmed(timestamp(seconds))
   }
 
-  fn timestamp(self) -> DateTime<Utc> {
+  pub(crate) fn timestamp(self) -> DateTime<Utc> {
     match self {
       Self::Confirmed(timestamp) | Self::Expected(timestamp) => timestamp,
     }
   }
-}
 
-impl Display for Blocktime {
-  fn fmt(&self, f: &mut Formatter) -> fmt::Result {
-    write!(f, "{}", self.timestamp())?;
-
-    if let Self::Expected(_) = self {
-      write!(f, " (expected)")?;
+  pub(crate) fn suffix(self) -> &'static str {
+    match self {
+      Self::Confirmed(_) => "",
+      Self::Expected(_) => " (expected)",
     }
-
-    Ok(())
-  }
-}
-
-#[cfg(test)]
-mod tests {
-  use super::*;
-
-  #[test]
-  fn display() {
-    assert_eq!(
-      Blocktime::confirmed(0).to_string(),
-      "1970-01-01 00:00:00 UTC"
-    );
-    assert_eq!(
-      Blocktime::Expected(timestamp(0)).to_string(),
-      "1970-01-01 00:00:00 UTC (expected)"
-    );
   }
 }

--- a/src/index.rs
+++ b/src/index.rs
@@ -632,7 +632,11 @@ impl Index {
         })?;
 
         Ok(Blocktime::Expected(
-          Utc::now() + chrono::Duration::seconds(10 * 60 * i64::try_from(expected_blocks).unwrap()),
+          Utc::now()
+            .checked_add_signed(chrono::Duration::seconds(
+              10 * 60 * i64::try_from(expected_blocks)?,
+            ))
+            .ok_or_else(|| anyhow!("block timestamp out of range"))?,
         ))
       }
     }

--- a/src/index.rs
+++ b/src/index.rs
@@ -614,7 +614,7 @@ impl Index {
     let height = height.n();
 
     match self.get_block_by_height(height)? {
-      Some(block) => Ok(Blocktime::Confirmed(block.header.time.into())),
+      Some(block) => Ok(Blocktime::confirmed(block.header.time)),
       None => {
         let tx = self.database.begin_read()?;
 
@@ -632,7 +632,7 @@ impl Index {
         })?;
 
         Ok(Blocktime::Expected(
-          Utc::now().timestamp() + 10 * 60 * i64::try_from(expected_blocks).unwrap(),
+          Utc::now() + chrono::Duration::seconds(10 * 60 * i64::try_from(expected_blocks).unwrap()),
         ))
       }
     }

--- a/src/index/updater.rs
+++ b/src/index/updater.rs
@@ -255,7 +255,7 @@ impl Updater {
     let mut sat_ranges_written = 0;
     let mut outputs_in_block = 0;
 
-    let time = Utc.timestamp_opt(block.header.time.into(), 0).unwrap();
+    let time = timestamp(block.header.time);
 
     log::info!(
       "Block {} at {} with {} transactions…",

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -43,7 +43,7 @@ use {
   },
   bitcoincore_rpc::{Client, RpcApi},
   chain::Chain,
-  chrono::{NaiveDateTime, TimeZone, Utc},
+  chrono::{DateTime, TimeZone, Utc},
   clap::{ArgGroup, Parser},
   derive_more::{Display, FromStr},
   html_escaper::{Escape, Trusted},
@@ -135,8 +135,8 @@ fn integration_test() -> bool {
     .unwrap_or(false)
 }
 
-fn timestamp(seconds: u32) -> NaiveDateTime {
-  NaiveDateTime::from_timestamp_opt(seconds.into(), 0).unwrap()
+fn timestamp(seconds: u32) -> DateTime<Utc> {
+  Utc.timestamp_opt(seconds.into(), 0).unwrap()
 }
 
 pub fn main() {

--- a/src/subcommand/server.rs
+++ b/src/subcommand/server.rs
@@ -1571,7 +1571,7 @@ mod tests {
     TestServer::new().assert_response_regex(
       "/sat/5000000000",
       StatusCode::OK,
-      ".*<dt>timestamp</dt><dd><time>.* \\(expected\\)</time></dd>.*",
+      ".*<dt>timestamp</dt><dd><time>.*</time> \\(expected\\)</dd>.*",
     );
   }
 

--- a/src/subcommand/server.rs
+++ b/src/subcommand/server.rs
@@ -1562,7 +1562,7 @@ mod tests {
     TestServer::new().assert_response_regex(
       "/sat/0",
       StatusCode::OK,
-      ".*<dt>time</dt><dd>2009-01-03 18:15:05</dd>.*",
+      ".*<dt>timestamp</dt><dd><time>2009-01-03 18:15:05 UTC</time></dd>.*",
     );
   }
 
@@ -1571,7 +1571,7 @@ mod tests {
     TestServer::new().assert_response_regex(
       "/sat/5000000000",
       StatusCode::OK,
-      ".*<dt>time</dt><dd>.* \\(expected\\)</dd>.*",
+      ".*<dt>timestamp</dt><dd><time>.* \\(expected\\)</time></dd>.*",
     );
   }
 

--- a/src/templates/block.rs
+++ b/src/templates/block.rs
@@ -43,7 +43,7 @@ mod tests {
         <dl>
           <dt>hash</dt><dd class=monospace>000000000019d6689c085ae165831e934ff763ae46a2a6c172b3f1b60a8ce26f</dd>
           <dt>target</dt><dd class=monospace>00000000ffff0000000000000000000000000000000000000000000000000000</dd>
-          <dt>timestamp</dt><dd>1231006505</dd>
+          <dt>timestamp</dt><dd><time>1231006505</time></dd>
           <dt>size</dt><dd>285</dd>
           <dt>weight</dt><dd>1140</dd>
         </dl>

--- a/src/templates/block.rs
+++ b/src/templates/block.rs
@@ -43,7 +43,7 @@ mod tests {
         <dl>
           <dt>hash</dt><dd class=monospace>000000000019d6689c085ae165831e934ff763ae46a2a6c172b3f1b60a8ce26f</dd>
           <dt>target</dt><dd class=monospace>00000000ffff0000000000000000000000000000000000000000000000000000</dd>
-          <dt>timestamp</dt><dd><time>1231006505</time></dd>
+          <dt>timestamp</dt><dd><time>2009-01-03 18:15:05 UTC</time></dd>
           <dt>size</dt><dd>285</dd>
           <dt>weight</dt><dd>1140</dd>
         </dl>

--- a/src/templates/inscription.rs
+++ b/src/templates/inscription.rs
@@ -12,7 +12,7 @@ pub(crate) struct InscriptionHtml {
   pub(crate) previous: Option<InscriptionId>,
   pub(crate) sat: Option<Sat>,
   pub(crate) satpoint: SatPoint,
-  pub(crate) timestamp: NaiveDateTime,
+  pub(crate) timestamp: DateTime<Utc>,
 }
 
 impl PageContent for InscriptionHtml {
@@ -68,7 +68,7 @@ mod tests {
           <dt>content type</dt>
           <dd>text/plain;charset=utf-8</dd>
           <dt>timestamp</dt>
-          <dd>1970-01-01 00:00:00</dd>
+          <dd><time>1970-01-01 00:00:00 UTC</time></dd>
           <dt>genesis height</dt>
           <dd>0</dd>
           <dt>genesis transaction</dt>

--- a/src/templates/sat.rs
+++ b/src/templates/sat.rs
@@ -24,7 +24,7 @@ mod tests {
       SatHtml {
         sat: Sat(0),
         satpoint: None,
-        blocktime: Blocktime::Confirmed(0),
+        blocktime: Blocktime::confirmed(0),
         inscription: None,
       }
       .to_string(),
@@ -41,7 +41,7 @@ mod tests {
           <dt>block</dt><dd><a href=/block/0>0</a></dd>
           <dt>offset</dt><dd>0</dd>
           <dt>rarity</dt><dd><span class=mythic>mythic</span></dd>
-          <dt>time</dt><dd>1970-01-01 00:00:00</dd>
+          <dt>timestamp</dt><dd><time>1970-01-01 00:00:00 UTC</time></dd>
         </dl>
         prev
         <a class=next href=/sat/1>next</a>
@@ -56,7 +56,7 @@ mod tests {
       SatHtml {
         sat: Sat(2099999997689999),
         satpoint: None,
-        blocktime: Blocktime::Confirmed(0),
+        blocktime: Blocktime::confirmed(0),
         inscription: None,
       }
       .to_string(),
@@ -73,7 +73,7 @@ mod tests {
           <dt>block</dt><dd><a href=/block/6929999>6929999</a></dd>
           <dt>offset</dt><dd>0</dd>
           <dt>rarity</dt><dd><span class=uncommon>uncommon</span></dd>
-          <dt>time</dt><dd>1970-01-01 00:00:00</dd>
+          <dt>timestamp</dt><dd><time>1970-01-01 00:00:00 UTC</time></dd>
         </dl>
         <a class=previous href=/sat/2099999997689998>prev</a>
         next
@@ -88,7 +88,7 @@ mod tests {
       SatHtml {
         sat: Sat(1),
         satpoint: None,
-        blocktime: Blocktime::Confirmed(0),
+        blocktime: Blocktime::confirmed(0),
         inscription: None,
       },
       r"<h1>Sat 1</h1>.*<a class=previous href=/sat/0>prev</a>\n<a class=next href=/sat/2>next</a>\n",
@@ -101,7 +101,7 @@ mod tests {
       SatHtml {
         sat: Sat(0),
         satpoint: None,
-        blocktime: Blocktime::Confirmed(0),
+        blocktime: Blocktime::confirmed(0),
         inscription: Some(inscription_id(1)),
       },
       r"<h1>Sat 0</h1>.*<dt>inscription</dt><dd class=thumbnails><a href=/inscription/1{64}i1>.*</a></dd>.*",
@@ -114,7 +114,7 @@ mod tests {
       SatHtml {
         sat: Sat::LAST,
         satpoint: None,
-        blocktime: Blocktime::Confirmed(0),
+        blocktime: Blocktime::confirmed(0),
         inscription: None,
       },
       r"<h1>Sat 2099999997689999</h1>.*<a class=previous href=/sat/2099999997689998>prev</a>\nnext\n",
@@ -127,7 +127,7 @@ mod tests {
       SatHtml {
         sat: Sat(0),
         satpoint: Some(satpoint(1, 0)),
-        blocktime: Blocktime::Confirmed(0),
+        blocktime: Blocktime::confirmed(0),
         inscription: None,
       },
       "<h1>Sat 0</h1>.*<dt>location</dt><dd class=monospace>1{64}:1:0</dd>.*",

--- a/static/index.js
+++ b/static/index.js
@@ -17,3 +17,7 @@ if (previous) {
     }
   });
 }
+
+for (let time of document.body.getElementsByTagName("time")) {
+  time.setAttribute('title', new Date(time.textContent));
+}

--- a/static/index.js
+++ b/static/index.js
@@ -1,3 +1,7 @@
+for (let time of document.body.getElementsByTagName('time')) {
+  time.setAttribute('title', new Date(time.textContent));
+}
+
 let next = document.querySelector('a.next');
 let previous = document.querySelector('a.previous');
 
@@ -19,7 +23,3 @@ window.addEventListener('keydown', e => {
       return;
   }
 });
-
-for (let time of document.body.getElementsByTagName('time')) {
-  time.setAttribute('title', new Date(time.textContent));
-}

--- a/templates/block.html
+++ b/templates/block.html
@@ -2,7 +2,7 @@
 <dl>
   <dt>hash</dt><dd class=monospace>{{self.hash}}</dd>
   <dt>target</dt><dd class=monospace>{{self.target}}</dd>
-  <dt>timestamp</dt><dd><time>{{self.block.header.time}}</time></dd>
+  <dt>timestamp</dt><dd><time>{{timestamp(self.block.header.time)}}</time></dd>
   <dt>size</dt><dd>{{self.block.size()}}</dd>
   <dt>weight</dt><dd>{{self.block.weight()}}</dd>
 %% if self.height.0 > 0 {

--- a/templates/block.html
+++ b/templates/block.html
@@ -2,7 +2,7 @@
 <dl>
   <dt>hash</dt><dd class=monospace>{{self.hash}}</dd>
   <dt>target</dt><dd class=monospace>{{self.target}}</dd>
-  <dt>timestamp</dt><dd>{{self.block.header.time}}</dd>
+  <dt>timestamp</dt><dd><time>{{self.block.header.time}}</time></dd>
   <dt>size</dt><dd>{{self.block.size()}}</dd>
   <dt>weight</dt><dd>{{self.block.weight()}}</dd>
 %% if self.height.0 > 0 {

--- a/templates/inscription.html
+++ b/templates/inscription.html
@@ -38,7 +38,7 @@
   <dd>{{ content_type }}</dd>
 %% }
   <dt>timestamp</dt>
-  <dd>{{ self.timestamp }}</dd>
+  <dd><time>{{ self.timestamp }}</time></dd>
   <dt>genesis height</dt>
   <dd>{{ self.genesis_height }}</dd>
   <dt>genesis transaction</dt>

--- a/templates/sat.html
+++ b/templates/sat.html
@@ -10,7 +10,7 @@
   <dt>block</dt><dd><a href=/block/{{self.sat.height()}}>{{ self.sat.height() }}</a></dd>
   <dt>offset</dt><dd>{{ self.sat.third() }}</dd>
   <dt>rarity</dt><dd><span class={{self.sat.rarity()}}>{{ self.sat.rarity() }}</span></dd>
-  <dt>time</dt><dd>{{ self.blocktime }}</dd>
+  <dt>timestamp</dt><dd><time>{{ self.blocktime }}</time></dd>
 %% if let Some((inscription)) = &self.inscription {
   <dt>inscription</dt><dd class=thumbnails>{{ Iframe::thumbnail(*inscription) }}</dd>
 %% }

--- a/templates/sat.html
+++ b/templates/sat.html
@@ -10,7 +10,7 @@
   <dt>block</dt><dd><a href=/block/{{self.sat.height()}}>{{ self.sat.height() }}</a></dd>
   <dt>offset</dt><dd>{{ self.sat.third() }}</dd>
   <dt>rarity</dt><dd><span class={{self.sat.rarity()}}>{{ self.sat.rarity() }}</span></dd>
-  <dt>timestamp</dt><dd><time>{{ self.blocktime }}</time></dd>
+  <dt>timestamp</dt><dd><time>{{self.blocktime.timestamp()}}</time>{{self.blocktime.suffix()}}</dd>
 %% if let Some((inscription)) = &self.inscription {
   <dt>inscription</dt><dd class=thumbnails>{{ Iframe::thumbnail(*inscription) }}</dd>
 %% }

--- a/tests/server.rs
+++ b/tests/server.rs
@@ -67,7 +67,7 @@ fn inscription_page() {
   <dt>content type</dt>
   <dd>text/plain;charset=utf-8</dd>
   <dt>timestamp</dt>
-  <dd>1970-01-01 00:00:02</dd>
+  <dd><time>1970-01-01 00:00:02 UTC</time></dd>
   <dt>genesis height</dt>
   <dd>2</dd>
   <dt>genesis transaction</dt>


### PR DESCRIPTION
Display timestamps as UTC datetime strings. Add local time titles using JS.