### PR TITLE
Round expected sat timestamps to the second

### DIFF
--- a/src/index.rs
+++ b/src/index.rs
@@ -9,6 +9,7 @@ use {
   super::*,
   bitcoin::BlockHeader,
   bitcoincore_rpc::{json::GetBlockHeaderResult, Auth, Client},
+  chrono::SubsecRound,
   indicatif::{ProgressBar, ProgressStyle},
   log::log_enabled,
   redb::{Database, ReadableTable, Table, TableDefinition, WriteStrategy, WriteTransaction},
@@ -633,6 +634,7 @@ impl Index {
 
         Ok(Blocktime::Expected(
           Utc::now()
+            .round_subsecs(0)
             .checked_add_signed(chrono::Duration::seconds(
               10 * 60 * i64::try_from(expected_blocks)?,
             ))

--- a/tests/server.rs
+++ b/tests/server.rs
@@ -286,3 +286,13 @@ fn inscriptions_page_has_next_and_previous() {
     ),
   );
 }
+
+#[test]
+fn expected_sat_time_is_rounded() {
+  let rpc_server = test_bitcoincore_rpc::spawn();
+
+  TestServer::spawn_with_args(&rpc_server, &[]).assert_response_regex(
+    "/sat/2099999997689999",
+    r".*<dt>timestamp</dt><dd><time>.* \d+:\d+:\d+ UTC</time> \(expected\)</dd>.*",
+  );
+}


### PR DESCRIPTION
> Q. How can you tell economists have a sense of humor?
> A. They use decimal points.

Fixes #1383.