### PR TITLE
nix: make it such that cargo test will run on nix

### DIFF
--- a/shell.nix
+++ b/shell.nix
@@ -8,5 +8,6 @@ in
     buildInputs = [
       nixpkgs.latest.rustChannels.stable.rust
       just
+      pkg-config openssl
     ];
   }

--- a/shell.nix
+++ b/shell.nix
@@ -6,8 +6,9 @@ in
   stdenv.mkDerivation {
     name = "ord-shell";
     buildInputs = [
-      nixpkgs.latest.rustChannels.stable.rust
       just
-      pkg-config openssl
+      nixpkgs.latest.rustChannels.stable.rust
+      openssl
+      pkg-config
     ];
   }


### PR DESCRIPTION
Add missing 'pkg-config openssl' so nix can run `cargo test`