### PR TITLE
Add options to inscribe straight to an address, and/or send commit change to an address

### DIFF
--- a/src/subcommand/preview.rs
+++ b/src/subcommand/preview.rs
@@ -80,6 +80,8 @@ impl Preview {
             no_backup: true,
             satpoint: None,
             dry_run: false,
+            commit_change: None,
+            inscription_destination: None,
           },
         )),
       }

--- a/src/subcommand/wallet/inscribe.rs
+++ b/src/subcommand/wallet/inscribe.rs
@@ -1,4 +1,4 @@
-use crate::subcommand::wallet::transaction_builder::CommitChangeAddress;
+use crate::subcommand::wallet::transaction_builder::ChangeAddresses;
 use {
   super::*,
   bitcoin::{
@@ -67,9 +67,9 @@ impl Inscribe {
     let inscriptions = index.get_inscriptions(None)?;
 
     let commit_tx_change = match self.commit_change {
-      Some(address) => CommitChangeAddress::Single(address),
+      Some(address) => ChangeAddresses::Single(address),
       None => {
-        CommitChangeAddress::Double([get_change_address(&client)?, get_change_address(&client)?])
+        ChangeAddresses::Double([get_change_address(&client)?, get_change_address(&client)?])
       }
     };
 
@@ -146,7 +146,7 @@ impl Inscribe {
     inscriptions: BTreeMap<SatPoint, InscriptionId>,
     network: Network,
     utxos: BTreeMap<OutPoint, Amount>,
-    change: CommitChangeAddress,
+    change: ChangeAddresses,
     destination: Address,
     fee_rate: FeeRate,
   ) -> Result<(Transaction, Transaction, TweakedKeyPair)> {

--- a/src/subcommand/wallet/send.rs
+++ b/src/subcommand/wallet/send.rs
@@ -1,5 +1,5 @@
 use super::*;
-use crate::subcommand::wallet::transaction_builder::CommitChangeAddress;
+use crate::subcommand::wallet::transaction_builder::ChangeAddresses;
 
 #[derive(Debug, Parser)]
 pub(crate) struct Send {
@@ -75,7 +75,7 @@ impl Send {
     };
 
     let change =
-      CommitChangeAddress::Double([get_change_address(&client)?, get_change_address(&client)?]);
+      ChangeAddresses::Double([get_change_address(&client)?, get_change_address(&client)?]);
 
     let unsigned_transaction = TransactionBuilder::build_transaction_with_postage(
       satpoint,

--- a/src/subcommand/wallet/send.rs
+++ b/src/subcommand/wallet/send.rs
@@ -1,4 +1,5 @@
 use super::*;
+use crate::subcommand::wallet::transaction_builder::CommitChangeAddress;
 
 #[derive(Debug, Parser)]
 pub(crate) struct Send {
@@ -73,7 +74,8 @@ impl Send {
       }
     };
 
-    let change = [get_change_address(&client)?, get_change_address(&client)?];
+    let change =
+      CommitChangeAddress::Double([get_change_address(&client)?, get_change_address(&client)?]);
 
     let unsigned_transaction = TransactionBuilder::build_transaction_with_postage(
       satpoint,

--- a/src/subcommand/wallet/transaction_builder.rs
+++ b/src/subcommand/wallet/transaction_builder.rs
@@ -64,20 +64,20 @@ enum Target {
   Postage,
 }
 
-pub enum CommitChangeAddress {
+pub enum ChangeAddresses {
   Single(Address),
   Double([Address; 2]),
 }
 
-impl From<Address> for CommitChangeAddress {
+impl From<Address> for ChangeAddresses {
   fn from(value: Address) -> Self {
-    CommitChangeAddress::Single(value)
+    ChangeAddresses::Single(value)
   }
 }
 
-impl From<[Address; 2]> for CommitChangeAddress {
+impl From<[Address; 2]> for ChangeAddresses {
   fn from(value: [Address; 2]) -> Self {
-    CommitChangeAddress::Double(value)
+    ChangeAddresses::Double(value)
   }
 }
 
@@ -138,7 +138,7 @@ impl TransactionBuilder {
     inscriptions: BTreeMap<SatPoint, InscriptionId>,
     amounts: BTreeMap<OutPoint, Amount>,
     recipient: Address,
-    change: CommitChangeAddress,
+    change: ChangeAddresses,
     fee_rate: FeeRate,
   ) -> Result<Transaction> {
     Self::new(
@@ -158,7 +158,7 @@ impl TransactionBuilder {
     inscriptions: BTreeMap<SatPoint, InscriptionId>,
     amounts: BTreeMap<OutPoint, Amount>,
     recipient: Address,
-    change: CommitChangeAddress,
+    change: ChangeAddresses,
     fee_rate: FeeRate,
     output_value: Amount,
   ) -> Result<Transaction> {
@@ -199,18 +199,18 @@ impl TransactionBuilder {
     inscriptions: BTreeMap<SatPoint, InscriptionId>,
     amounts: BTreeMap<OutPoint, Amount>,
     recipient: Address,
-    change: CommitChangeAddress,
+    change: ChangeAddresses,
     fee_rate: FeeRate,
     target: Target,
   ) -> Result<Self> {
     let change_addresses = match change {
-      CommitChangeAddress::Single(address) => {
+      ChangeAddresses::Single(address) => {
         if address == recipient {
           return Err(Error::DuplicateAddress(recipient));
         }
         BTreeSet::from([address])
       }
-      CommitChangeAddress::Double(addresses) => {
+      ChangeAddresses::Double(addresses) => {
         if addresses.contains(&recipient) {
           return Err(Error::DuplicateAddress(recipient));
         }
@@ -700,7 +700,7 @@ mod tests {
       BTreeMap::new(),
       utxos.clone().into_iter().collect(),
       recipient(),
-      CommitChangeAddress::Double([change(0), change(1)]),
+      ChangeAddresses::Double([change(0), change(1)]),
       FeeRate::try_from(1.0).unwrap(),
       Target::Postage,
     )


### PR DESCRIPTION
if you want to make sure that the change from the commit transaction goes to a specific address, you can now provide the `--commit-change` option. Note that if a specific satpoint is being inscribed, we might need two change addresses because the UTXO might need splitting, so passing both the `--satpoint` option and the `--commit-change` option will throw an error.

Also, now you can set the `--inscription_destination` option to set the reveal transaction output to a specific address.

I thought making the `change` field that gets passed around an enum was the best way to encapsulate the optionality. Happy for feedback on if there's a different way we want to model this. 