### PR TITLE
Use p2p to fetch blocks and headers

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -106,9 +106,9 @@ dependencies = [
 
 [[package]]
 name = "anyhow"
-version = "1.0.68"
+version = "1.0.69"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2cb2f989d18dd141ab8ae82f64d1a8cdd37e0840f73a406896cf5e99502fab61"
+checksum = "224afbd727c3d6e4b90103ece64b8d1b67fbb1973b1046c2281eed3f3803f800"
 dependencies = [
  "backtrace",
 ]
@@ -408,7 +408,7 @@ dependencies = [
  "matchit",
  "memchr",
  "mime",
- "percent-encoding",
+ "percent-encoding 2.2.0",
  "pin-project-lite",
  "rustversion",
  "serde",
@@ -774,7 +774,7 @@ dependencies = [
  "base64 0.13.1",
  "hkdf",
  "hmac",
- "percent-encoding",
+ "percent-encoding 2.2.0",
  "rand 0.8.5",
  "sha2 0.9.9",
  "time 0.2.27",
@@ -1200,7 +1200,7 @@ version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a9c384f161156f5260c24a097c56119f9be8c798586aecc13afbcbe7b7e26bf8"
 dependencies = [
- "percent-encoding",
+ "percent-encoding 2.2.0",
 ]
 
 [[package]]
@@ -1553,7 +1553,7 @@ dependencies = [
  "serde_json",
  "serde_qs",
  "serde_urlencoded",
- "url",
+ "url 2.3.0",
 ]
 
 [[package]]
@@ -1640,6 +1640,17 @@ name = "ident_case"
 version = "1.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b9e0384b61958566e926dc50660321d12159025e767c18e043daf26b70104c39"
+
+[[package]]
+name = "idna"
+version = "0.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "38f09e0f0b1fb55fdee1f17470ad800da77af5186a1a76c026b679358b7e844e"
+dependencies = [
+ "matches",
+ "unicode-bidi",
+ "unicode-normalization",
+]
 
 [[package]]
 name = "idna"
@@ -2201,6 +2212,7 @@ dependencies = [
  "tokio-util 0.7.4",
  "tower-http",
  "unindent",
+ "url 1.7.2",
 ]
 
 [[package]]
@@ -2281,6 +2293,12 @@ checksum = "a8835c273a76a90455d7344889b0964598e3316e2a79ede8e36f16bdcf2228b8"
 dependencies = [
  "base64 0.13.1",
 ]
+
+[[package]]
+name = "percent-encoding"
+version = "1.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "31010dd2e1ac33d5b46a5b413495239882813e0369f8ed8a5e266f173602f831"
 
 [[package]]
 name = "percent-encoding"
@@ -2631,7 +2649,7 @@ dependencies = [
  "mime",
  "native-tls",
  "once_cell",
- "percent-encoding",
+ "percent-encoding 2.2.0",
  "pin-project-lite",
  "serde",
  "serde_json",
@@ -2639,7 +2657,7 @@ dependencies = [
  "tokio",
  "tokio-native-tls",
  "tower-service",
- "url",
+ "url 2.3.0",
  "wasm-bindgen",
  "wasm-bindgen-futures",
  "web-sys",
@@ -2793,7 +2811,7 @@ dependencies = [
  "thiserror",
  "tokio",
  "tokio-util 0.7.4",
- "url",
+ "url 2.3.0",
  "webpki-roots",
  "x509-parser",
 ]
@@ -2970,7 +2988,7 @@ version = "0.8.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c7715380eec75f029a4ef7de39a9200e0a63823176b759d055b613f5a87df6a6"
 dependencies = [
- "percent-encoding",
+ "percent-encoding 2.2.0",
  "serde",
  "thiserror",
 ]
@@ -3283,6 +3301,7 @@ dependencies = [
 name = "test-bitcoincore-rpc"
 version = "0.0.1"
 dependencies = [
+ "anyhow",
  "bitcoin",
  "hex",
  "jsonrpc-core",
@@ -3650,13 +3669,24 @@ checksum = "a156c684c91ea7d62626509bce3cb4e1d9ed5c4d978f7b4352658f96a4c26b4a"
 
 [[package]]
 name = "url"
+version = "1.7.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dd4e7c0d531266369519a4aa4f399d748bd37043b00bde1e4ff1f60a120b355a"
+dependencies = [
+ "idna 0.1.5",
+ "matches",
+ "percent-encoding 1.0.1",
+]
+
+[[package]]
+name = "url"
 version = "2.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "22fe195a4f217c25b25cb5058ced57059824a678474874038dc88d211bf508d3"
 dependencies = [
  "form_urlencoded",
- "idna",
- "percent-encoding",
+ "idna 0.2.1",
+ "percent-encoding 2.2.0",
  "serde",
 ]
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -53,6 +53,7 @@ tokio = { version = "1.17.0", features = ["rt-multi-thread"] }
 tokio-stream = "0.1.9"
 tokio-util = {version = "0.7.3", features = ["compat"] }
 tower-http = { version = "0.3.3", features = ["compression-br", "compression-gzip", "cors", "set-header"] }
+url = "1.3.0"
 
 [dev-dependencies]
 executable-path = "1.0.0"

--- a/README.md
+++ b/README.md
@@ -93,7 +93,7 @@ Syncing
 -------
 
 `ord` requires a synced `bitcoind` node with `-txindex` to build the index of
-satoshi locations. `ord` communicates with `bitcoind` via RPC.
+satoshi locations. `ord` communicates with `bitcoind` via RPC and P2P.
 
 If `bitcoind` is run locally by the same user, without additional
 configuration, `ord` should find it automatically by reading the `.cookie` file

--- a/src/chain.rs
+++ b/src/chain.rs
@@ -31,6 +31,15 @@ impl Chain {
     }
   }
 
+  pub(crate) fn default_p2p_port(self) -> u16 {
+    match self {
+      Self::Mainnet => 8333,
+      Self::Regtest => 18444,
+      Self::Signet => 38333,
+      Self::Testnet => 18333,
+    }
+  }
+
   pub(crate) fn inscription_content_size_limit(self) -> Option<usize> {
     match self {
       Self::Mainnet | Self::Regtest => None,

--- a/src/index.rs
+++ b/src/index.rs
@@ -945,6 +945,8 @@ mod tests {
         "ord".into(),
         "--rpc-url".into(),
         rpc_server.url().into(),
+        "--p2p-port".into(),
+        rpc_server.p2p_port().into(),
         "--data-dir".into(),
         tempdir.path().into(),
         "--cookie-file".into(),

--- a/src/index/p2p.rs
+++ b/src/index/p2p.rs
@@ -1,0 +1,183 @@
+use {
+  anyhow::{bail, ensure, Context, Result},
+  bitcoin::{
+    consensus::{encode, Decodable},
+    hashes::Hash,
+    network::{
+      constants,
+      message::{NetworkMessage, RawNetworkMessage},
+      message_blockdata::{GetHeadersMessage, Inventory},
+      message_network::VersionMessage,
+      Address,
+    },
+    secp256k1::{self, rand::Rng},
+    Block, BlockHash, BlockHeader, Network,
+  },
+  log::{debug, trace, warn},
+  std::{
+    io::{ErrorKind, Write},
+    net::{IpAddr, Ipv4Addr, SocketAddr, TcpStream},
+    sync::{
+      mpsc::{sync_channel, Receiver, SyncSender},
+      Arc,
+    },
+    time::{SystemTime, UNIX_EPOCH},
+  },
+};
+
+pub(crate) struct Connection {
+  msg_send: SyncSender<NetworkMessage>,
+  blocks_recv: Receiver<Block>,
+  headers_recv: Receiver<Vec<BlockHeader>>,
+}
+
+impl Connection {
+  pub(crate) fn get_headers(&mut self, begin_hash: Option<BlockHash>) -> Result<Vec<BlockHeader>> {
+    let msg = GetHeadersMessage::new(
+      vec![begin_hash.unwrap_or_else(BlockHash::all_zeros)],
+      BlockHash::all_zeros(),
+    );
+
+    self.msg_send.send(NetworkMessage::GetHeaders(msg))?;
+
+    let headers = self.headers_recv.recv()?;
+
+    Ok(headers)
+  }
+
+  pub(crate) fn for_blocks<F>(&mut self, hashes: &[BlockHash], mut func: F) -> Result<()>
+  where
+    F: FnMut(Block),
+  {
+    let invs: Vec<Inventory> = hashes
+      .iter()
+      .map(|hash| Inventory::WitnessBlock(*hash))
+      .collect();
+
+    self.msg_send.send(NetworkMessage::GetData(invs))?;
+
+    for hash in hashes {
+      let block = self.blocks_recv.recv()?;
+      ensure!(
+        block.block_hash() == *hash,
+        "got unexpected block for {hash:?}"
+      );
+      func(block);
+    }
+
+    Ok(())
+  }
+
+  pub(crate) fn connect(network: Network, address: SocketAddr) -> Result<Self> {
+    let conn = Arc::new(
+      TcpStream::connect(address)
+        .with_context(|| format!("Failed to connect to {network} node at {address:?}"))?,
+    );
+
+    let (tx_send, tx_recv) = sync_channel::<NetworkMessage>(1);
+
+    let stream = Arc::clone(&conn);
+    crate::thread::spawn(move || loop {
+      use std::net::Shutdown;
+      let msg = match tx_recv.recv() {
+        Ok(msg) => msg,
+        Err(_) => {
+          // p2p_loop is closed, so tx_send is disconnected
+          debug!("closing p2p_send thread: no more messages to send");
+          // close the stream reader (p2p_recv thread may block on it)
+          if let Err(e) = stream.shutdown(Shutdown::Read) {
+            warn!("failed to shutdown p2p connection: {}", e)
+          }
+          return;
+        }
+      };
+      trace!("send: {:?}", msg);
+      let raw_msg = RawNetworkMessage {
+        magic: network.magic(),
+        payload: msg,
+      };
+      let _ = (&*stream)
+        .write_all(encode::serialize(&raw_msg).as_slice())
+        .context("p2p failed to send");
+    });
+
+    let (blocks_send, blocks_recv) = sync_channel::<Block>(10);
+    let (headers_send, headers_recv) = sync_channel::<Vec<BlockHeader>>(1);
+    let (init_send, init_recv) = sync_channel::<()>(0);
+
+    tx_send.send(build_version_message())?;
+
+    let stream = Arc::clone(&conn);
+    let tx_send_clone = tx_send.clone();
+    crate::thread::spawn(move || loop {
+      let raw_msg = RawNetworkMessage::consensus_decode(&mut &*stream);
+
+      let msg = match raw_msg {
+        Ok(raw_msg) => {
+          assert_eq!(raw_msg.magic, network.magic());
+          raw_msg.payload
+        }
+        Err(encode::Error::Io(e)) if e.kind() == ErrorKind::UnexpectedEof => {
+          debug!("closing p2p_recv thread: connection closed");
+          return Ok(());
+        }
+        Err(e) => bail!("failed to recv a message from peer: {}", e),
+      };
+
+      match msg {
+        NetworkMessage::GetHeaders(_) => {
+          tx_send_clone.send(NetworkMessage::Headers(vec![]))?;
+        }
+        NetworkMessage::Version(version) => {
+          debug!("peer version: {:?}", version);
+          tx_send_clone.send(NetworkMessage::Verack)?;
+        }
+        NetworkMessage::Inv(_) => (),
+        NetworkMessage::Ping(nonce) => {
+          tx_send_clone.send(NetworkMessage::Pong(nonce))?; // connection keep-alive
+        }
+        NetworkMessage::Verack => {
+          init_send.send(())?; // peer acknowledged our version
+        }
+        NetworkMessage::Block(block) => blocks_send.send(block)?,
+        NetworkMessage::Headers(headers) => headers_send.send(headers)?,
+        NetworkMessage::Alert(_) => (), // https://bitcoin.org/en/alert/2016-11-01-alert-retirement
+        NetworkMessage::Addr(_) => (),  // unused
+        msg => warn!("unexpected message: {:?}", msg),
+      }
+    });
+
+    init_recv.recv()?; // wait until `verack` is received
+
+    Ok(Connection {
+      msg_send: tx_send,
+      blocks_recv,
+      headers_recv,
+    })
+  }
+}
+
+fn build_version_message() -> NetworkMessage {
+  let addr = SocketAddr::new(IpAddr::V4(Ipv4Addr::new(0, 0, 0, 0)), 0);
+  let timestamp: i64 = SystemTime::now()
+    .duration_since(UNIX_EPOCH)
+    .expect("Time error")
+    .as_secs()
+    .try_into()
+    .unwrap();
+
+  let services = constants::ServiceFlags::NONE;
+  const VERSION: &str = env!("CARGO_PKG_VERSION");
+
+  NetworkMessage::Version(VersionMessage {
+    version: constants::PROTOCOL_VERSION,
+    services,
+    timestamp,
+    receiver: Address::new(&addr, services),
+    sender: Address::new(&addr, services),
+    nonce: secp256k1::rand::thread_rng().gen(),
+    user_agent: format!("/ord:{VERSION}/"),
+    start_height: 0,
+    relay: false,
+  })
+}

--- a/src/options.rs
+++ b/src/options.rs
@@ -37,6 +37,8 @@ pub(crate) struct Options {
   pub(crate) regtest: bool,
   #[clap(long, help = "Connect to Bitcoin Core RPC at <RPC_URL>.")]
   pub(crate) rpc_url: Option<String>,
+  #[clap(long, help = "Connect to Bitcoin Core P2P at <P2P_PORT>.")]
+  pub(crate) p2p_port: Option<u16>,
   #[clap(long, short, help = "Use signet. Equivalent to `--chain signet`.")]
   pub(crate) signet: bool,
   #[clap(long, short, help = "Use testnet. Equivalent to `--chain testnet`.")]
@@ -78,6 +80,12 @@ impl Options {
         self.wallet
       )
     })
+  }
+
+  pub(crate) fn p2p_port(&self) -> u16 {
+    self
+      .p2p_port
+      .unwrap_or_else(|| self.chain().default_p2p_port())
   }
 
   pub(crate) fn cookie_file(&self) -> Result<PathBuf> {

--- a/src/subcommand/preview.rs
+++ b/src/subcommand/preview.rs
@@ -20,6 +20,7 @@ impl Preview {
     let tmpdir = TempDir::new()?;
 
     let rpc_port = TcpListener::bind("127.0.0.1:0")?.local_addr()?.port();
+    let p2p_port = TcpListener::bind("127.0.0.1:0")?.local_addr()?.port();
 
     let bitcoin_data_dir = tmpdir.path().join("bitcoin");
 
@@ -34,8 +35,9 @@ impl Preview {
         })
         .arg("-regtest")
         .arg("-txindex")
-        .arg("-listen=0")
+        .arg("-listen=1")
         .arg(format!("-rpcport={rpc_port}"))
+        .arg(format!("-port={p2p_port}"))
         .spawn()
         .context("failed to spawn `bitcoind`")?,
     );
@@ -45,6 +47,7 @@ impl Preview {
       bitcoin_data_dir: Some(bitcoin_data_dir),
       data_dir: Some(tmpdir.path().into()),
       rpc_url: Some(format!("127.0.0.1:{rpc_port}")),
+      p2p_port: Some(p2p_port),
       index_sats: true,
       ..Options::default()
     };

--- a/src/subcommand/server.rs
+++ b/src/subcommand/server.rs
@@ -974,8 +974,9 @@ mod tests {
       };
 
       let (options, server) = parse_server_args(&format!(
-        "ord --chain regtest --rpc-url {} --cookie-file {} --data-dir {} {config_args} {} server --http-port {} --address 127.0.0.1 {}",
+        "ord --chain regtest --rpc-url {} --p2p-port {} --cookie-file {} --data-dir {} {config_args} {} server --http-port {} --address 127.0.0.1 {}",
         bitcoin_rpc_server.url(),
+        bitcoin_rpc_server.p2p_port(),
         cookiefile.to_str().unwrap(),
         tempdir.path().to_str().unwrap(),
         ord_args.join(" "),

--- a/test-bitcoincore-rpc/Cargo.toml
+++ b/test-bitcoincore-rpc/Cargo.toml
@@ -8,6 +8,7 @@ homepage = "https://github.com/casey/ord"
 repository = "https://github.com/casey/ord"
 
 [dependencies]
+anyhow = "1.0.69"
 bitcoin = { version = "0.29.1", features = ["serde", "rand"] }
 hex = "0.4.3"
 jsonrpc-core = "18.0.0"

--- a/tests/command_builder.rs
+++ b/tests/command_builder.rs
@@ -34,6 +34,7 @@ pub(crate) struct CommandBuilder {
   expected_stderr: Expected,
   expected_stdout: Expected,
   rpc_server_url: Option<String>,
+  p2p_port: Option<String>,
   tempdir: TempDir,
 }
 
@@ -45,6 +46,7 @@ impl CommandBuilder {
       expected_stderr: Expected::String(String::new()),
       expected_stdout: Expected::String(String::new()),
       rpc_server_url: None,
+      p2p_port: None,
       tempdir: TempDir::new().unwrap(),
     }
   }
@@ -57,6 +59,7 @@ impl CommandBuilder {
   pub(crate) fn rpc_server(self, rpc_server: &test_bitcoincore_rpc::Handle) -> Self {
     Self {
       rpc_server_url: Some(rpc_server.url()),
+      p2p_port: Some(rpc_server.p2p_port()),
       ..self
     }
   }
@@ -98,6 +101,8 @@ impl CommandBuilder {
       command.args([
         "--rpc-url",
         rpc_server_url,
+        "--p2p-port",
+        self.p2p_port.as_ref().unwrap(),
         "--cookie-file",
         cookiefile.to_str().unwrap(),
       ]);

--- a/tests/test_server.rs
+++ b/tests/test_server.rs
@@ -24,8 +24,9 @@ impl TestServer {
       .port();
 
     let child = Command::new(executable_path("ord")).args(format!(
-      "--rpc-url {} --bitcoin-data-dir {} --data-dir {} {} server --http-port {port} --address 127.0.0.1",
+      "--rpc-url {} --p2p-port {} --bitcoin-data-dir {} --data-dir {} {} server --http-port {port} --address 127.0.0.1",
       rpc_server.url(),
+      rpc_server.p2p_port(),
       tempdir.path().display(),
       tempdir.path().display(),
       args.join(" "),


### PR DESCRIPTION
Uses the p2p interface to fetch block hashes and headers much more efficiently. Fetches headers 2k at a time, and fetches blocks in chunks of 10.

Syncs the first 200k or so blocks much faster, but haven't benchmarked the whole chain. I don't suspect it will be much more gain for the whole chain since most of the time will be spent indexing to the db, and blocks are already being fetched in the background. However, this is a much more efficient way of fetching this data.

Still have to fix tests because they don't support connecting via p2p yet.

Closes https://github.com/casey/ord/issues/1502.