### PR TITLE
switch recoverable block fetching error message to warning

### DIFF
--- a/src/index/updater.rs
+++ b/src/index/updater.rs
@@ -188,7 +188,7 @@ impl Updater {
         }
         Ok(None) => break,
         Err(err) => {
-          log::error!("failed to fetch block {height}: {err}");
+          log::warn!("failed to fetch block {height}: {err}");
           break;
         }
       }


### PR DESCRIPTION
I think we actually forgot to switch this recoverable error message to `warn` in https://github.com/casey/ord/pull/1466 (I missed it in my review)