### PR TITLE
Include inscription ID in text inscription decode error

### DIFF
--- a/src/subcommand/server.rs
+++ b/src/subcommand/server.rs
@@ -802,7 +802,7 @@ impl Server {
         Ok(
           PreviewTextHtml {
             text: str::from_utf8(content)
-              .map_err(|err| anyhow!("Failed to decode UTF-8: {err}"))?,
+              .map_err(|err| anyhow!("Failed to decode {inscription_id} text: {err}"))?,
           }
           .into_response(),
         )


### PR DESCRIPTION
I saw this error in the logs repeatedly, and was curious what inscription it was.