### PR TITLE
feat: add ability to connect to bitcoind using inline credentials

### DIFF
--- a/src/options.rs
+++ b/src/options.rs
@@ -148,24 +148,24 @@ impl Options {
   }
 
   pub(crate) fn bitcoin_rpc_client(&self) -> Result<Client> {
-    let cookie_file = self
-      .cookie_file()
-      .map_err(|err| anyhow!("failed to get cookie file path: {err}"))?;
-
     let rpc_url = self.rpc_url();
 
-    log::info!(
-      "Connecting to Bitcoin Core RPC server at {rpc_url} using credentials from `{}`",
-      cookie_file.display()
-    );
+    let auth = if let Some((user, pass)) = self.rpc_userpass() {
+      log::info!(
+        "Connecting to Bitcoin Core RPC server at {rpc_url} using rpc_username `{user}`",
+      );
+      Auth::UserPass(user, pass)
+    } else {
+      let cookie_file = self.cookie_file()
+        .map_err(|err| anyhow!("failed to get cookie file path: {err}"))?;
+      log::info!(
+        "Connecting to Bitcoin Core RPC server at {rpc_url} using credentials from `{}`",
+        cookie_file.display()
+      );
+      Auth::CookieFile(cookie_file)
+    };
 
-    let client =
-      Client::new(&rpc_url, Auth::CookieFile(cookie_file.clone())).with_context(|| {
-        format!(
-          "failed to connect to Bitcoin Core RPC at {rpc_url} using cookie file {}",
-          cookie_file.display()
-        )
-      })?;
+    let client = Client::new(&rpc_url, auth.clone()).context("failed to connect to RPC URL")?;
 
     let rpc_chain = match client.get_blockchain_info()?.chain.as_str() {
       "main" => Chain::Mainnet,

--- a/src/options.rs
+++ b/src/options.rs
@@ -20,6 +20,10 @@ pub(crate) struct Options {
   pub(crate) config: Option<PathBuf>,
   #[clap(long, help = "Load Bitcoin Core RPC cookie file from <COOKIE_FILE>.")]
   pub(crate) cookie_file: Option<PathBuf>,
+  #[clap(long, help = "Authenticate Bitcoin Core RPC using BasicAuth.")]
+  pub(crate) rpc_username: Option<String>,
+  #[clap(long, help = "Authenticate Bitcoin Core RPC using BasicAuth.")]
+  pub(crate) rpc_password: Option<String>,
   #[clap(long, help = "Store index in <DATA_DIR>.")]
   pub(crate) data_dir: Option<PathBuf>,
   #[clap(
@@ -78,6 +82,20 @@ impl Options {
         self.wallet
       )
     })
+  }
+
+  pub(crate) fn rpc_userpass(&self) -> Option<(String, String)> {
+    let user = match &self.rpc_username {
+      Some(username) => username.clone(),
+      None => return None
+    };
+
+    let pass = match &self.rpc_password {
+      Some(password) => password.clone(),
+      None => "".to_string()
+    };
+
+    return Some((user, pass));
   }
 
   pub(crate) fn cookie_file(&self) -> Result<PathBuf> {


### PR DESCRIPTION
Hey @casey!
I'm trying to use `ord` locally, within a containerized setup. 
The cookie method is unfortunately not an option, was there a particular reason for not adding the user/pass strategy?
This PR was tested locally and is fixing my issue.
Thanks!
