### PR TITLE
Increase deployed mempool size to 1024 megabytes

### DIFF
--- a/deploy/bitcoin.conf
+++ b/deploy/bitcoin.conf
@@ -1,2 +1,3 @@
 datadir=/var/lib/bitcoind
+maxmempool=1024
 txindex=1


### PR DESCRIPTION
If the mempool grows above 300 megabytes, the default size, our node will start dropping transactions. I'd like to keep everything in the mempool, so increase the size to 1024 megs. (can fit at least 256 four meggers)