### PR TITLE
Add prettierignore for all files

### DIFF
--- a/.prettierignore
+++ b/.prettierignore
@@ -1,0 +1,2 @@
+# ignore everything
+/*


### PR DESCRIPTION
Will follow up with specific settings in a separate PR, but this disables prettier for those who have it enabled on save as discussed in #1586.

`prettier -c .` output before:

```
Checking formatting...
...(truncated)...
[warn] Code style issues found in 35 files. Forgot to run Prettier?
```

`prettier -c .` output after:

```
Checking formatting...
All matched files use Prettier code style!
```