### PR TITLE
Use REST interface for calling get_raw_transaction

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2179,6 +2179,7 @@ dependencies = [
  "hex",
  "html-escaper",
  "http",
+ "hyper",
  "indicatif",
  "lazy_static",
  "log",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -31,6 +31,7 @@ futures = "0.3.21"
 hex = "0.4.3"
 html-escaper = "0.2.0"
 http = "0.2.6"
+hyper = { version = "0.14.24", features = ["http1", "client"] }
 indicatif = "0.17.1"
 lazy_static = "1.4.0"
 log = "0.4.14"

--- a/src/index.rs
+++ b/src/index.rs
@@ -19,6 +19,7 @@ use {
 };
 
 mod entry;
+mod rest;
 mod rtx;
 mod updater;
 

--- a/src/index/rest.rs
+++ b/src/index/rest.rs
@@ -1,0 +1,41 @@
+use {
+  anyhow::Result,
+  bitcoin::{consensus::deserialize, BlockHash, Transaction, Txid},
+  hyper::{client::HttpConnector, Client, Uri},
+  std::str::FromStr,
+};
+
+pub(crate) struct Rest {
+  client: Client<HttpConnector>,
+  url: String,
+}
+
+impl Rest {
+  pub(crate) fn new(url: &str) -> Self {
+    let url = if !url.starts_with("http://") {
+      "http://".to_string() + url
+    } else {
+      url.to_string()
+    };
+    Rest {
+      client: Client::new(),
+      url,
+    }
+  }
+
+  pub(crate) async fn get_block_hash(&self, height: u32) -> Result<BlockHash> {
+    let url = format!("{}/rest/blockhashbyheight/{height}.bin", self.url);
+    let res = self.client.get(Uri::from_str(&url)?).await?;
+    let buf = hyper::body::to_bytes(res).await?;
+    let block_hash = deserialize(&buf)?;
+    Ok(block_hash)
+  }
+
+  pub(crate) async fn get_raw_transaction(&self, txid: &Txid) -> Result<Transaction> {
+    let url = format!("{}/rest/tx/{txid:x}.bin", self.url);
+    let res = self.client.get(Uri::from_str(&url)?).await?;
+    let buf = hyper::body::to_bytes(res).await?;
+    let tx = deserialize(&buf)?;
+    Ok(tx)
+  }
+}

--- a/src/index/updater/inscription_updater.rs
+++ b/src/index/updater/inscription_updater.rs
@@ -16,6 +16,7 @@ pub(super) struct InscriptionUpdater<'a, 'db, 'tx> {
   height: u64,
   id_to_satpoint: &'a mut Table<'db, 'tx, &'static InscriptionIdValue, &'static SatPointValue>,
   index: &'a Index,
+  value_receiver: &'a mut Option<Receiver<u64>>,
   id_to_entry: &'a mut Table<'db, 'tx, &'static InscriptionIdValue, InscriptionEntryValue>,
   lost_sats: u64,
   next_number: u64,
@@ -33,6 +34,7 @@ impl<'a, 'db, 'tx> InscriptionUpdater<'a, 'db, 'tx> {
     height: u64,
     id_to_satpoint: &'a mut Table<'db, 'tx, &'static InscriptionIdValue, &'static SatPointValue>,
     index: &'a Index,
+    value_receiver: &'a mut Option<Receiver<u64>>,
     id_to_entry: &'a mut Table<'db, 'tx, &'static InscriptionIdValue, InscriptionEntryValue>,
     lost_sats: u64,
     number_to_id: &'a mut Table<'db, 'tx, u64, &'static InscriptionIdValue>,
@@ -54,6 +56,7 @@ impl<'a, 'db, 'tx> InscriptionUpdater<'a, 'db, 'tx> {
       height,
       id_to_satpoint,
       index,
+      value_receiver,
       id_to_entry,
       lost_sats,
       next_number,
@@ -97,6 +100,13 @@ impl<'a, 'db, 'tx> InscriptionUpdater<'a, 'db, 'tx> {
           .remove(&tx_in.previous_output.store())?
         {
           value.value()
+        } else if let Some(value_receiver) = self.value_receiver.as_mut() {
+          value_receiver.blocking_recv().ok_or_else(|| {
+            anyhow!(
+              "failed to get transaction for {}",
+              tx_in.previous_output.txid
+            )
+          })?
         } else {
           self
             .index


### PR DESCRIPTION
Closes https://github.com/casey/ord/issues/1558.

Use the REST endpoint for fetching raw transactions instead of RPC endpoint. Only really useful when implementing https://github.com/casey/ord/issues/1364 by reverting https://github.com/casey/ord/pull/1357.

When combined with https://github.com/casey/ord/pull/1516, I synced to 775812 (without `--index-sats`) in 1 hour 6 minutes. And no more pesky JSON-RPC errors. 

The progress bar is kind of silly now though. It should really show progress from first inscription block to current height if no `--index-sats`.

This needs to have bitcoind run with `-rest` though, otherwise painful slowness and rpc errors.