### PR TITLE
add support for gltf-binary media

### DIFF
--- a/src/media.rs
+++ b/src/media.rs
@@ -31,6 +31,7 @@ impl Media {
     ("image/png", Media::Image, &["png"]),
     ("image/svg+xml", Media::Iframe, &["svg"]),
     ("image/webp", Media::Image, &["webp"]),
+    ("model/gltf-binary", Media::Unknown, &["glb"]),
     ("model/stl", Media::Unknown, &["stl"]),
     ("text/html;charset=utf-8", Media::Iframe, &["html"]),
     ("text/plain;charset=utf-8", Media::Text, &["txt"]),


### PR DESCRIPTION
Adds support for the `gltf-binary` 3D model file type with the `.glb` extension. It is a widely adopted binary format for 3D models which will be useful for storing on-chain 3D data.

More info about the `gltf-binary` type: https://www.iana.org/assignments/media-types/model/gltf-binary