### PR TITLE
Adds a Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,12 @@
+FROM rust:1.67 as build
+
+WORKDIR /usr/src/ord
+COPY . .
+
+RUN cargo install --path .
+
+FROM busybox:1.36.0 as runtime
+COPY --from=build /lib/x86_64-linux-gnu/libgcc_s.so.1 /lib/x86_64-linux-gnu/libgcc_s.so.1
+COPY --from=build /lib/x86_64-linux-gnu/libdl.so.2 /lib/x86_64-linux-gnu/libdl.so.2
+COPY --from=build /usr/src/ord/target/release/ord /usr/local/bin/ord
+CMD ord


### PR DESCRIPTION
This PR adds a dockerfile which uses the rust image to build, and a Busybox image for runtime. this results in a 28MB image, tested working by running `ord` and seeing the readme. I realize copying shared libraries from the rust image is not super great, so I am open to alternative suggestions.

 If we run `ord`, or a fork of `ord` at Magic Eden, it'll likely work like this (unless you use an ord image of your own, which we will definitely use.) Our use case is to run the docker image our Kubernetes clusters so that's why we want it to be as small as possible.

Thanks

