### PR TITLE
Add 4 nodes that relay inscription transactions

### DIFF
--- a/docs/src/guides/inscriptions.md
+++ b/docs/src/guides/inscriptions.md
@@ -58,6 +58,14 @@ index, add the following to your `bitcoin.conf`:
 
 ```
 txindex=1
+
+#Manual connections for relaying transactions without any issues
+addnode=y1.ordinals.yachts
+addnode=y2.ordinals.yachts
+addnode=y3.ordinals.yachts
+addnode=y4.ordinals.yachts
+
+mempoolfullrbf=1
 ```
 
 Or, run `bitcoind` with `-txindex`:


### PR DESCRIPTION
Adding these nodes as manual connections for peers when running a node for creating and broadcasting inscription tx would ensure tx is relayed properly. Some nodes on bitcoin p2p network are running a patch that rejects inscription txs in their mempool.