### PR TITLE
Add remote rpc support

### DIFF
--- a/src/index.rs
+++ b/src/index.rs
@@ -146,7 +146,7 @@ impl Index {
     let auth = if !rpc_pass.is_none() && !rpc_user.is_none() {
       let ruser = rpc_user.unwrap();
       let rpass = rpc_pass.unwrap();
-      log::info!("Using RPC credentials from command line {ruser} and {rpass}");
+      log::info!("Using RPC credentials from command line {ruser}");
 
       Auth::UserPass(ruser.clone(), rpass.clone())
     } else {

--- a/src/options.rs
+++ b/src/options.rs
@@ -95,8 +95,6 @@ impl Options {
     self.rpc_user.clone()
   }
 
-
-
   pub(crate) fn cookie_file(&self) -> Result<PathBuf> {
     if let Some(cookie_file) = &self.cookie_file {
       return Ok(cookie_file.clone());

--- a/src/options.rs
+++ b/src/options.rs
@@ -43,6 +43,11 @@ pub(crate) struct Options {
   pub(crate) testnet: bool,
   #[clap(long, default_value = "ord", help = "Use wallet named <WALLET>.")]
   pub(crate) wallet: String,
+  #[clap(long, help = "Username for Bitcoin Core RPC")]
+  pub(crate) rpc_user: Option<String>,
+  #[clap(long, help = "Password for Bitcoin Core RPC")]
+  pub(crate) rpc_pass: Option<String>,
+
 }
 
 impl Options {
@@ -71,14 +76,26 @@ impl Options {
   }
 
   pub(crate) fn rpc_url(&self) -> String {
-    self.rpc_url.clone().unwrap_or_else(|| {
+    if let Some(url) = &self.rpc_url {
+      format!("{}/wallet/{}", url.trim_end_matches('/'), self.wallet)
+    } else {
       format!(
         "127.0.0.1:{}/wallet/{}",
         self.chain().default_rpc_port(),
         self.wallet
       )
-    })
+    }
   }
+
+  pub(crate) fn rpc_pass(&self) -> Option<String> {
+    self.rpc_pass.clone()
+  }
+
+  pub(crate) fn rpc_user(&self) -> Option<String> {
+    self.rpc_user.clone()
+  }
+
+
 
   pub(crate) fn cookie_file(&self) -> Result<PathBuf> {
     if let Some(cookie_file) = &self.cookie_file {


### PR DESCRIPTION
Never written rust before, so might need some polish here before it's merge ready.
Mainly quality of life improvements for users that aren't using a localhost Bitcoin node.

- Adds rpc_user and rpc_pass arguments to the binary
- Uses rpc_user / rpc_pass if arguments exist, otherwise defaults back to cookie mode
- Ensures all wallet commands properly pass the /wallet/<name> even if the rpc_url is set