### PR TITLE
install.sh case $uname_target: additional err msg

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -113,6 +113,7 @@ if [ -z ${target-} ]; then
     x86_64-Linux) target=x86_64-unknown-linux-gnu;;
     *)
       err 'Could not determine target from output of `uname -m`-`uname -s`, please use `--target`:' $uname_target
+      err 'Please try building from source: https://github.com/casey/ord#building'
     ;;
   esac
 fi


### PR DESCRIPTION
add additional err msg to build from source for users who's arch falls outside of the list (e.g. aarch64-Linux). Should help address https://github.com/casey/ord/issues/1628 and mitigate future issues on the topic.

```
case $uname_target in
    arm64-Darwin) target=aarch64-apple-darwin;;
    x86_64-Darwin) target=x86_64-apple-darwin;;
    x86_64-Linux) target=x86_64-unknown-linux-gnu;;
    *)
      err 'Could not determine target from output of `uname -m`-`uname -s`, please use `--target`:' $uname_target
      err 'Please try building from source: https://github.com/casey/ord#building'
    ;;
  esac
```