### PR TITLE
Add option to inscribe BitTorrent (V1) infohashes

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -34,6 +34,7 @@ html-escaper = "0.2.0"
 http = "0.2.6"
 hyper = { version = "0.14.24", features = ["http1", "client"] }
 indicatif = "0.17.1"
+lava_torrent = { version = "0.8.1" }
 lazy_static = "1.4.0"
 log = "0.4.14"
 mime = "0.3.16"
@@ -56,6 +57,7 @@ tokio = { version = "1.17.0", features = ["rt-multi-thread"] }
 tokio-stream = "0.1.9"
 tokio-util = {version = "0.7.3", features = ["compat"] }
 tower-http = { version = "0.3.3", features = ["compression-br", "compression-gzip", "cors", "set-header"] }
+urlencoding = "2.1.2"
 
 [dev-dependencies]
 executable-path = "1.0.0"

--- a/src/inscription.rs
+++ b/src/inscription.rs
@@ -105,6 +105,14 @@ impl Inscription {
     str::from_utf8(self.content_type.as_ref()?).ok()
   }
 
+  pub(crate) fn torrent_data(&self) -> Option<super::torrent::TorrentHashData> {
+    if self.content_type() == Some("sha2,btih") {
+      super::torrent::parse_inscription_data(self.body()?)
+    } else {
+      None
+    }
+  }
+
   #[cfg(test)]
   pub(crate) fn to_witness(&self) -> Witness {
     let builder = script::Builder::new();

--- a/src/inscription.rs
+++ b/src/inscription.rs
@@ -23,7 +23,6 @@ pub(crate) struct Inscription {
 }
 
 impl Inscription {
-  #[cfg(test)]
   pub(crate) fn new(content_type: Option<Vec<u8>>, body: Option<Vec<u8>>) -> Self {
     Self { content_type, body }
   }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -119,6 +119,7 @@ mod sat_point;
 pub mod subcommand;
 mod tally;
 mod templates;
+mod torrent;
 mod wallet;
 
 type Result<T = (), E = Error> = std::result::Result<T, E>;

--- a/src/media.rs
+++ b/src/media.rs
@@ -13,6 +13,7 @@ pub(crate) enum Media {
   Text,
   Unknown,
   Video,
+  HashTorrent,
 }
 
 impl Media {
@@ -37,6 +38,7 @@ impl Media {
     ("text/plain;charset=utf-8", Media::Text, &["txt"]),
     ("video/mp4", Media::Video, &["mp4"]),
     ("video/webm", Media::Video, &["webm"]),
+    ("sha2,btih", Media::HashTorrent, &[]),
   ];
 
   pub(crate) fn content_type_for_path(path: &Path) -> Result<&'static str, Error> {

--- a/src/subcommand/preview.rs
+++ b/src/subcommand/preview.rs
@@ -86,6 +86,10 @@ impl Preview {
             dry_run: false,
             no_limit: false,
             destination: None,
+            torrent: false,
+            torrent_path: None,
+            torrent_tracker: "".to_string(),
+            torrent_peers: "".to_string(),
           },
         )),
       }

--- a/src/subcommand/server.rs
+++ b/src/subcommand/server.rs
@@ -8,7 +8,8 @@ use {
   crate::templates::{
     BlockHtml, ClockSvg, HomeHtml, InputHtml, InscriptionHtml, InscriptionsHtml, OutputHtml,
     PageContent, PageHtml, PreviewAudioHtml, PreviewImageHtml, PreviewPdfHtml, PreviewTextHtml,
-    PreviewUnknownHtml, PreviewVideoHtml, RangeHtml, RareTxt, SatHtml, TransactionHtml,
+    PreviewTorrentHashHtml, PreviewUnknownHtml, PreviewVideoHtml, RangeHtml, RareTxt, SatHtml,
+    TransactionHtml,
   },
   axum::{
     body,
@@ -809,6 +810,13 @@ impl Server {
       }
       Media::Unknown => Ok(PreviewUnknownHtml.into_response()),
       Media::Video => Ok(PreviewVideoHtml { inscription_id }.into_response()),
+      Media::HashTorrent => {
+        let torrent_data = inscription
+          .torrent_data()
+          .ok_or_not_found(|| format!("inscription {inscription_id} torrent commitment data"))?;
+
+        Ok(PreviewTorrentHashHtml(torrent_data).into_response())
+      }
     };
   }
 

--- a/src/templates.rs
+++ b/src/templates.rs
@@ -11,8 +11,8 @@ pub(crate) use {
   output::OutputHtml,
   page_config::PageConfig,
   preview::{
-    PreviewAudioHtml, PreviewImageHtml, PreviewPdfHtml, PreviewTextHtml, PreviewUnknownHtml,
-    PreviewVideoHtml,
+    PreviewAudioHtml, PreviewImageHtml, PreviewPdfHtml, PreviewTextHtml, PreviewTorrentHashHtml,
+    PreviewUnknownHtml, PreviewVideoHtml,
   },
   range::RangeHtml,
   rare::RareTxt,

--- a/src/templates/preview.rs
+++ b/src/templates/preview.rs
@@ -27,3 +27,6 @@ pub(crate) struct PreviewUnknownHtml;
 pub(crate) struct PreviewVideoHtml {
   pub(crate) inscription_id: InscriptionId,
 }
+
+#[derive(boilerplate::Boilerplate)]
+pub(crate) struct PreviewTorrentHashHtml(pub(crate) super::torrent::TorrentHashData);

--- a/src/torrent.rs
+++ b/src/torrent.rs
@@ -1,0 +1,95 @@
+use {
+  super::{inscription::Inscription, Error},
+  anyhow::Context,
+  bitcoin::hashes::{sha256, Hash},
+  lava_torrent::{bencode::BencodeElem, torrent::v1::TorrentBuilder},
+  std::path::{Path, PathBuf},
+  std::{ffi::OsString, fs},
+  urlencoding::encode,
+};
+
+use bitcoin::hashes::hex::ToHex;
+
+// Content type to identify Bittorent v1 hash commitments (v1 is implied by btih, v2 uses btmh)
+const CONTENT_TYPE: &str = "sha2,btih";
+
+// Bittorrent piece length (1MB)
+const PIECE_LENGTH: i64 = 1048576;
+
+// Default tracker URIs (included in .torrent & magnet links)
+// TODO support multiple, add wss tracker
+pub const DEFAULT_TRACKER: &str = "udp://tracker.ordinals.com";
+
+// Default webseed URL (included in .torrent & magnet links)
+// Expected to serve files at WEBSEED_URL/INFOHASH/FILENAME and the .torrent metadata file at WEBSEED_URL/INFOHASH.torrent
+pub const DEFAULT_WEBSEED: &str = "https://webseed.ordinals.com";
+
+// Bootstrap peers for DHT discovery (included in .torrent & magnet links)
+pub const DEFAULT_PEER: &str = "dht.ordinals.com:6885";
+
+pub(crate) fn make_torrent_inscription(
+  file_path: impl AsRef<Path>,
+  torrent_path: Option<impl AsRef<Path>>,
+  tracker_url: &str,
+  peer_addr: &str,
+) -> Result<Inscription, Error> {
+  // TorrentBuilder requires absolute paths
+  let file_path = fs::canonicalize(file_path)?;
+
+  // Create the torrent and gets its infohash
+  let torrent = TorrentBuilder::new(&file_path, PIECE_LENGTH)
+    .set_announce(Some(tracker_url.to_string()))
+    .add_extra_field("nodes".to_string(), bencode_nodes(peer_addr))
+    .build()
+    .with_context(|| "TorrentBuilder failed")?;
+  let infohash = torrent.info_hash_bytes();
+
+  // Write the .torrent file (by default, to <path>.torrent)
+  let torrent_path = get_torrent_path(&file_path, torrent_path);
+  log::info!(
+    "Writing torrent with infohash {} to {}",
+    infohash.to_hex(),
+    torrent_path.display()
+  );
+  torrent
+    .write_into_file(torrent_path)
+    .with_context(|| "failed writing .torrent file")?;
+
+  // Calculate the file's SHA256
+  // TODO streaming hash to avoid loading the entire file in memory
+  let contents =
+    fs::read(&file_path).with_context(|| format!("io error reading {}", file_path.display()))?;
+  let sha256hash = sha256::Hash::hash(&contents).into_inner().to_vec();
+
+  // Create an inscription for the SHA256+infohash
+  Ok(Inscription::new(
+    Some(CONTENT_TYPE.into()),
+    Some([sha256hash, infohash].concat()),
+  ))
+}
+
+fn get_torrent_path(file_path: &Path, torrent_path: Option<impl AsRef<Path>>) -> PathBuf {
+  if let Some(torrent_path) = torrent_path {
+    torrent_path.as_ref().to_owned()
+  } else {
+    let mut fileoss: OsString = file_path.into();
+    fileoss.push(".torrent");
+    fileoss.into()
+  }
+}
+
+fn bencode_nodes(nodes: &str) -> BencodeElem {
+  BencodeElem::List(
+    nodes
+      .trim()
+      .split(" ")
+      .filter_map(|node| {
+        let mut parts = node.split(":"); // host:port
+        Some(BencodeElem::List(vec![
+          parts.next()?.into(),
+          parts.next()?.parse::<i64>().ok()?.into(),
+        ]))
+      })
+      .collect(),
+  )
+}

--- a/templates/inscription.html
+++ b/templates/inscription.html
@@ -1,3 +1,4 @@
+%% use bitcoin::hashes::hex::ToHex;
 <h1>Inscription {{ self.number }}</h1>
 <div class=inscription>
 %% if let Some(previous) = self.previous {
@@ -36,6 +37,15 @@
 %% if let Some(content_type) = self.inscription.content_type() {
   <dt>content type</dt>
   <dd>{{ content_type }}</dd>
+%% }
+%% if let Some(torrent_data) = self.inscription.torrent_data() {
+  <dt>file sha256</dt>
+  <dd class=monospace>{{torrent_data.sha256.to_hex()}}</dd>
+  <dt>torrent infohash</dt>
+  <dd class=monospace>{{torrent_data.infohash.to_hex()}}</dd>
+  <dt>torrent magnet</dt>
+  %% let magnet_uri = torrent_data.magnet_uri();
+  <dd><a href="{{ magnet_uri }}">download</a> <a href="https://instant.io/#{{magnet_uri}}"><em>[instant.io]</em></a></dd>
 %% }
   <dt>timestamp</dt>
   <dd><time>{{ self.timestamp }}</time></dd>

--- a/templates/preview-torrent-hash.html
+++ b/templates/preview-torrent-hash.html
@@ -1,0 +1,20 @@
+%% use bitcoin::hashes::hex::ToHex;
+
+<!doctype html>
+<html lang=en>
+  <head>
+    <meta charset=utf-8>
+    <link rel=stylesheet href=/static/index.css>
+  </head>
+  <body>
+    <dl>
+      <dt>file sha256</dt>
+      <dd class=monospace>{{self.0.sha256.to_hex()}}</dd>
+      <dt>torrent infohash</dt>
+      <dd class=monospace>{{self.0.infohash.to_hex()}}</dd>
+      <dt>torrent magnet</dt>
+      %% let magnet_uri = self.0.magnet_uri();
+      <dd><a href={{ magnet_uri }}>download</a> <a href="https://instant.io/#{{magnet_uri}}">[instant.io]</a></dd>
+    </dl>
+  </body>
+</html>


### PR DESCRIPTION
This adds a new `--torrent` CLI flag (plus some related `--torrent-xxx` options) to `ord wallet inscribe`, which automatically creates a torrent for the given file (by default, in the same directory with a `.torrent` extension) and inscribes its SHA-128 infohash alongside the file's (regular) SHA-256 using the `sha2,btih` content type.

The explorer was also adapted to render torrent inscriptions with the infohash/sha256 hex and a magnet link.

With this, files can be stored off-chain on the BitTorrent P2P network while the Bitcoin blockchain is used to commit to the file and to provide its `infohash`, which acts as a locator for obtaining the file from BitTorrent (using DHT or trackers).

---

Why not IPFS?

I haven't really found a compelling reason to prefer IPFS. It can work better for files that are duplicated across multiple torrents but it should rarely be the case here. Also bittorrent has a more mature ecosystem, better tooling, and more people already have a client installed.

Why not BitTorrent V2?

I couldn't find a Rust library that supports it. Also it appears that many bittorrent clients don't support V2 yet, including [webtorrent](https://github.com/webtorrent/webtorrent) (which is pretty neat and worth supporting imo).

Why inscribe the SHA-256 too?

Mainly to have an easy way for users to verify the file if they get it through some other non-torrent means (and therefore don't have the torrent metadata, which is necessary to confirm the infohash matches the file -- edit: [not quite true](https://github.com/casey/ord/pull/1805#issuecomment-1439371596)) and to avoid relying solely on the SHA-128 used by BitTorrent V1. This also enables the Nostr storage mentioned below.

---

It's possible to improve file availability and download speeds by providing some centrally managed services:

- A tracker. Having a tracker specifically for ordinal/inscription users could help improve peer discovery. The tracker could be set to only accept infohashes that were inscribed on the blockchain, so that it couldn't be used as a free-for-all tracker (with [webtorrent/bittorrent-tracker](https://github.com/webtorrent/bittorrent-tracker), the `filter` callback can be used to check with an external database/api).

- A DHT bootstrap node. Having ordinal users connect to it can similarly help improve connectivity. (some possible options are [bittorrent/bootstrap-dht](https://github.com/bittorrent/bootstrap-dht) and [webtorrent/bittorrent-dht](https://github.com/webtorrent/bittorrent-dht))

- A WebSeed mirror. [BEP 19](https://www.bittorrent.org/beps/bep_0019.html) defines a standard for adding HTTP mirrors to torrents, which can be used in addition to normal peers or as a fallback if there are none.

  The ordinals.com server (or whoever else is interested in providing a mirror) would need to run a daemon that: (1) Listens for infohash inscriptions, (2) Downloads the torrents associated with them (probably with some size limit), and (3) Makes them available for download over HTTP.

  It appears that [webtorrent](https://github.com/webtorrent/webtorrent) can be used to achieve this quite easily. It even includes a [built-in http server](https://github.com/webtorrent/webtorrent/blob/master/docs/api.md#clientcreateserveropts-force) that could be used as the webseed server [0].

This PR assumes that such services exists (on `tracker.ordinals.com`/`dht.ordinals.com`/`webseed.ordinals.com`), and embeds them into the generated `.torrent` files and magnet links. If you'd like me to, I can remove this.

[0] I submitted https://github.com/webtorrent/webtorrent/pull/2487 to add support for serving the `.torrent` file, which this PR assumes to be available on the webseed server at `<WEBSEED_URL>/<INFOHASH>.torrent`. This makes magnet links work even when there are no p2p seeds.

---

Using Nostr for storage

This can be achieved with this PR by inscribing an `event.json` file with the Nostr event in the [JSON serialization format](https://github.com/nostr-protocol/nips/blob/master/01.md#events-and-signatures) used for event IDs. For example:

```bash
echo -n '[0,"mypubkey",1676880792,1,[],"hello nostr!"]' > event.json
ord wallet inscribe --torrent event.json
```

This will inscribe the Nostr event ID as the committed SHA-256, which can then be looked up on Nostr relays. The inscribed torrent can be used as a backup, or ignored.

---

Possible future work:

- Display file previews directly in the browser, either via a webseed http mirror [1] or using an in-browser webtorrent client (its pretty neat that the torrent can be downloaded right in the browser! -- although with the caveat that it can only connect to other [WebRTC-enabled](https://github.com/webtorrent/webtorrent/issues/369) peers. See [instant.io](https://instant.io) for a cool demonstration of it.)

- Because the inscriptions here are pretty small, this could theoretically use `OP_RETURN`, which would avoid the complexities of the two commit/reveal transactions.

[1] I submitted https://github.com/webtorrent/webtorrent/pull/2488 to make embedding files from the webseed slightly easier.
