### PR TITLE
Skip indexing inscriptions when below first inscription

### DIFF
--- a/src/index/updater.rs
+++ b/src/index/updater.rs
@@ -344,7 +344,9 @@ impl Updater {
 
     let mut outpoint_to_value = wtx.open_table(OUTPOINT_TO_VALUE)?;
 
-    if !self.index_sats {
+    let index_inscriptions = self.height >= index.first_inscription_height;
+
+    if index_inscriptions {
       // Send all missing input outpoints to be fetched right away
       let txids = block
         .txdata
@@ -476,6 +478,7 @@ impl Updater {
           &mut sat_ranges_written,
           &mut outputs_in_block,
           &mut inscription_updater,
+          index_inscriptions,
         )?;
 
         coinbase_inputs.extend(input_sat_ranges);
@@ -490,6 +493,7 @@ impl Updater {
           &mut sat_ranges_written,
           &mut outputs_in_block,
           &mut inscription_updater,
+          index_inscriptions,
         )?;
       }
 
@@ -548,8 +552,11 @@ impl Updater {
     sat_ranges_written: &mut u64,
     outputs_traversed: &mut u64,
     inscription_updater: &mut InscriptionUpdater,
+    index_inscriptions: bool,
   ) -> Result {
-    inscription_updater.index_transaction_inscriptions(tx, txid, Some(input_sat_ranges))?;
+    if index_inscriptions {
+      inscription_updater.index_transaction_inscriptions(tx, txid, Some(input_sat_ranges))?;
+    }
 
     for (vout, output) in tx.output.iter().enumerate() {
       let outpoint = OutPoint {


### PR DESCRIPTION
After #1759 we skip indexing transactions when below the first inscription height, and fetch missing inputs afterwards. However, we still try and index inscriptions below the first inscription block during `--index-sats`.

This PR skips transactions below the first inscription block for `--index-sats` as well. With this method combined with #1812  I was able to sync `--index-sats` in 23 hours 42 minutes.