### PR TITLE
Fix the ord wallet descriptors

### DIFF
--- a/src/subcommand/wallet.rs
+++ b/src/subcommand/wallet.rs
@@ -136,7 +136,7 @@ fn derive_and_import_descriptor(
     active: Some(true),
     range: None,
     next_index: None,
-    internal: Some(!change),
+    internal: Some(change),
     label: None,
   })?;
 


### PR DESCRIPTION
Mark change addresses as change addresses and receiving addresses as receiving addresses rather than the other way around.

Closes #1801.