### PR TITLE
Correct reveal tx fee calculation

### DIFF
--- a/src/subcommand/wallet/inscribe.rs
+++ b/src/subcommand/wallet/inscribe.rs
@@ -92,7 +92,7 @@ impl Inscribe {
 
     utxos.insert(
       reveal_tx.input[0].previous_output,
-      Amount::from_sat(unsigned_commit_tx.output[0].value),
+      Amount::from_sat(unsigned_commit_tx.output[reveal_tx.input[0].previous_output.vout as usize].value),
     );
 
     let fees =

--- a/src/subcommand/wallet/inscribe.rs
+++ b/src/subcommand/wallet/inscribe.rs
@@ -92,7 +92,9 @@ impl Inscribe {
 
     utxos.insert(
       reveal_tx.input[0].previous_output,
-      Amount::from_sat(unsigned_commit_tx.output[reveal_tx.input[0].previous_output.vout as usize].value),
+      Amount::from_sat(
+        unsigned_commit_tx.output[reveal_tx.input[0].previous_output.vout as usize].value,
+      ),
     );
 
     let fees =


### PR DESCRIPTION
The inscribe command would calculate the reveal tx fee incorrectly whenever the reveal tx wasn't funded by the first output of the commit tx as is the case when you inscribe on a satpoint with a non zero offset.

In such cases if the first output of the commit tx was much smaller than the 2nd the inscribe command would fail due to calculating a negative fee.

This commit fixes the problem and closes #1844.