### PR TITLE
Makes bitcoind a forking daemon

### DIFF
--- a/deploy/bitcoin.conf
+++ b/deploy/bitcoin.conf
@@ -1,3 +1,4 @@
 datadir=/var/lib/bitcoind
 maxmempool=1024
 txindex=1
+daemon=1

--- a/deploy/bitcoind.service
+++ b/deploy/bitcoind.service
@@ -26,7 +26,7 @@ StateDirectory=bitcoind
 StateDirectoryMode=0710
 TimeoutStartSec=infinity
 TimeoutStopSec=600
-Type=simple
+Type=forking
 User=bitcoin
 
 [Install]


### PR DESCRIPTION
Unless I'm mistaken, we'd like bitcoind to run as a daemon, and doing so requires it to be a forking process under systemd . 

See:
- https://github.com/bitcoin/bitcoin/blob/master/contrib/init/bitcoind.service#L33
- https://manpages.ubuntu.com/manpages/impish/man5/systemd.service.5.html
- https://bitcoin.stackexchange.com/questions/74116/bitcoind-daemon-mode