### PR TITLE
Complain when a satpoint's offset is off the end of the output.

### DIFF
--- a/src/subcommand/wallet/transaction_builder.rs
+++ b/src/subcommand/wallet/transaction_builder.rs
@@ -50,6 +50,7 @@ pub enum Error {
   },
   NotEnoughCardinalUtxos,
   NotInWallet(SatPoint),
+  OutOfRange(SatPoint, u64),
   UtxoContainsAdditionalInscription {
     outgoing_satpoint: SatPoint,
     inscribed_satpoint: SatPoint,
@@ -72,6 +73,7 @@ impl fmt::Display for Error {
         dust_value,
       } => write!(f, "output value is below dust value: {output_value} < {dust_value}"),
       Error::NotInWallet(outgoing_satpoint) => write!(f, "outgoing satpoint {outgoing_satpoint} not in wallet"),
+      Error::OutOfRange(outgoing_satpoint, maximum) => write!(f, "outgoing satpoint {outgoing_satpoint} offset higher than maximum {maximum}"),
       Error::NotEnoughCardinalUtxos => write!(
         f,
         "wallet does not contain enough cardinal UTXOs, please add additional funds to wallet."
@@ -226,6 +228,10 @@ impl TransactionBuilder {
       .amounts
       .get(&self.outgoing.outpoint)
       .ok_or(Error::NotInWallet(self.outgoing))?;
+
+    if self.outgoing.offset >= amount.to_sat() {
+      return Err(Error::OutOfRange(self.outgoing, amount.to_sat() - 1));
+    }
 
     self.utxos.remove(&self.outgoing.outpoint);
     self.inputs.push(self.outgoing.outpoint);


### PR DESCRIPTION
When giving `wallet send` or `wallet inscribe` a satpoint with an invalid offset, ord crashes.

This fixes that. 

Before:

    $ ord wallet send --fee-rate 1 $addr $txid:0:9999999
    thread 'main' panicked at 'Amount subtraction error', ~/.cargo/registry/src/github.com-1ecc6299db9ec823/bitcoin-0.29.2/src/util/amount.rs:722:9
    note: run with `RUST_BACKTRACE=1` environment variable to display a backtrace

After:

    $ ord wallet send --fee-rate 1 $addr $txid:0:9999999
    error: outgoing satpoint $txid:0:9999999 offset higher than maximum 1999