### PR TITLE
Better interrupt message

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -146,14 +146,14 @@ const INTERRUPT_LIMIT: u64 = 5;
 pub fn main() {
   env_logger::init();
 
-  println!("Detected Ctrl-C, attempting to shut down ord gracefully. Press Ctrl-C {INTERRUPT_LIMIT} times to force shutdown.");
-
   ctrlc::set_handler(move || {
     LISTENERS
       .lock()
       .unwrap()
       .iter()
       .for_each(|handle| handle.graceful_shutdown(Some(Duration::from_millis(100))));
+
+    println!("Detected Ctrl-C, attempting to shut down ord gracefully. Press Ctrl-C {INTERRUPT_LIMIT} times to force shutdown.");
 
     let interrupts = INTERRUPTS.fetch_add(1, atomic::Ordering::Relaxed);
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -141,8 +141,12 @@ fn timestamp(seconds: u32) -> DateTime<Utc> {
   Utc.timestamp_opt(seconds.into(), 0).unwrap()
 }
 
+const INTERRUPT_LIMIT: u64 = 5;
+
 pub fn main() {
   env_logger::init();
+
+  println!("Detected Ctrl-C, attempting to shut down ord gracefully. Press Ctrl-C {INTERRUPT_LIMIT} times to force shutdown.");
 
   ctrlc::set_handler(move || {
     LISTENERS
@@ -153,7 +157,7 @@ pub fn main() {
 
     let interrupts = INTERRUPTS.fetch_add(1, atomic::Ordering::Relaxed);
 
-    if interrupts > 5 {
+    if interrupts > INTERRUPT_LIMIT {
       process::exit(1);
     }
   })


### PR DESCRIPTION
Print a message saying that Ord has responded to a Ctrl-C event and will shut down immeidately with 5 Ctrl-C's.