### PR TITLE
metadata string added for inscribe file

### DIFF
--- a/src/inscription.rs
+++ b/src/inscription.rs
@@ -15,7 +15,7 @@ const PROTOCOL_ID: &[u8] = b"ord";
 
 const BODY_TAG: &[u8] = &[];
 const CONTENT_TYPE_TAG: &[u8] = &[1];
-const METADATA_TAG: &[u8] = &[2];
+const METADATA_TAG: &[u8] = &[3];
 
 #[derive(Debug, PartialEq, Clone)]
 pub(crate) struct Inscription {
@@ -388,7 +388,7 @@ mod tests {
         b"ord",
         &[1],
         b"text/plain;charset=utf-8",
-        &[3],
+        &[5],
         b"bar",
         &[],
         b"ord",
@@ -759,7 +759,7 @@ mod tests {
   #[test]
   fn unknown_odd_fields_are_ignored() {
     assert_eq!(
-      InscriptionParser::parse(&envelope(&[b"ord", &[3], &[0]])),
+      InscriptionParser::parse(&envelope(&[b"ord", &[5], &[0]])),
       Ok(Inscription {
         content_type: None,
         body: None,
@@ -771,7 +771,7 @@ mod tests {
   #[test]
   fn unknown_even_fields_are_invalid() {
     assert_eq!(
-      InscriptionParser::parse(&envelope(&[b"ord", &[4], &[0]])),
+      InscriptionParser::parse(&envelope(&[b"ord", &[2], &[0]])),
       Err(InscriptionError::UnrecognizedEvenField),
     );
   }

--- a/src/inscription.rs
+++ b/src/inscription.rs
@@ -358,6 +358,8 @@ mod tests {
         b"ord",
         &[1],
         b"text/plain;charset=utf-8",
+        &[1],
+        b"text/plain;charset=utf-8",
         &[],
         b"ord",
       ])),
@@ -532,8 +534,6 @@ mod tests {
     assert_eq!(
       InscriptionParser::parse(&envelope(&[
         b"ord",
-        &[2],
-        b"Hello World",
         &[1],
         b"text/plain;charset=utf-8",
         &[],
@@ -771,7 +771,7 @@ mod tests {
   #[test]
   fn unknown_even_fields_are_invalid() {
     assert_eq!(
-      InscriptionParser::parse(&envelope(&[b"ord", &[2], &[0]])),
+      InscriptionParser::parse(&envelope(&[b"ord", &[4], &[0]])),
       Err(InscriptionError::UnrecognizedEvenField),
     );
   }

--- a/src/inscription.rs
+++ b/src/inscription.rs
@@ -20,7 +20,7 @@ const CONTENT_TYPE_TAG: &[u8] = &[1];
 pub(crate) struct Inscription {
   body: Option<Vec<u8>>,
   content_type: Option<Vec<u8>>,
-  pub metadata: Option<&'static str>,
+  metadata: Option<&'static str>,
 }
 
 impl Inscription {
@@ -98,6 +98,10 @@ impl Inscription {
 
   pub(crate) fn into_body(self) -> Option<Vec<u8>> {
     self.body
+  }
+
+  pub(crate) fn metadata(&self) -> Option<&'static str> {
+    self.metadata
   }
 
   pub(crate) fn content_length(&self) -> Option<usize> {

--- a/src/subcommand/preview.rs
+++ b/src/subcommand/preview.rs
@@ -86,6 +86,7 @@ impl Preview {
             dry_run: false,
             no_limit: false,
             destination: None,
+            metadata: None,
           },
         )),
       }

--- a/src/subcommand/server.rs
+++ b/src/subcommand/server.rs
@@ -824,11 +824,12 @@ impl Server {
     let inscription = index
       .get_inscription_by_id(inscription_id)?
       .ok_or_not_found(|| format!("inscription {inscription_id}"))?;
+    
+    let metadata = inscription.metadata;
 
     let satpoint = index
       .get_inscription_satpoint_by_id(inscription_id)?
       .ok_or_not_found(|| format!("inscription {inscription_id}"))?;
-
     let output = index
       .get_transaction(satpoint.outpoint.txid)?
       .ok_or_not_found(|| format!("inscription {inscription_id} current transaction"))?
@@ -863,6 +864,7 @@ impl Server {
         sat: entry.sat,
         satpoint,
         timestamp: timestamp(entry.timestamp),
+        metadata,
       }
       .page(page_config, index.has_sat_index()?),
     )

--- a/src/subcommand/server.rs
+++ b/src/subcommand/server.rs
@@ -825,7 +825,7 @@ impl Server {
       .get_inscription_by_id(inscription_id)?
       .ok_or_not_found(|| format!("inscription {inscription_id}"))?;
     
-    let metadata = inscription.metadata;
+    let metadata = inscription.metadata();
 
     let satpoint = index
       .get_inscription_satpoint_by_id(inscription_id)?

--- a/src/subcommand/server.rs
+++ b/src/subcommand/server.rs
@@ -825,8 +825,6 @@ impl Server {
       .get_inscription_by_id(inscription_id)?
       .ok_or_not_found(|| format!("inscription {inscription_id}"))?;
     
-    let metadata = inscription.metadata();
-
     let satpoint = index
       .get_inscription_satpoint_by_id(inscription_id)?
       .ok_or_not_found(|| format!("inscription {inscription_id}"))?;
@@ -863,8 +861,7 @@ impl Server {
         previous,
         sat: entry.sat,
         satpoint,
-        timestamp: timestamp(entry.timestamp),
-        metadata,
+        timestamp: timestamp(entry.timestamp)
       }
       .page(page_config, index.has_sat_index()?),
     )

--- a/src/subcommand/wallet/inscribe.rs
+++ b/src/subcommand/wallet/inscribe.rs
@@ -54,11 +54,18 @@ pub(crate) struct Inscribe {
   pub(crate) dry_run: bool,
   #[clap(long, help = "Send inscription to <DESTINATION>.")]
   pub(crate) destination: Option<Address>,
+  #[clap(long, help = "Metadata String")]
+  pub(crate) metadata: Option<String>,
 }
 
 impl Inscribe {
   pub(crate) fn run(self, options: Options) -> Result {
-    let inscription = Inscription::from_file(options.chain(), &self.file)?;
+    let metadata = if let Some(metadata) = self.metadata {
+      Some(Box::leak(metadata.into_boxed_str()) as &str)
+    } else {
+      None
+    };
+    let inscription = Inscription::from_file(options.chain(), &self.file, metadata)?;
 
     let index = Index::open(&options)?;
     index.update()?;

--- a/src/templates/inscription.rs
+++ b/src/templates/inscription.rs
@@ -14,7 +14,6 @@ pub(crate) struct InscriptionHtml {
   pub(crate) sat: Option<Sat>,
   pub(crate) satpoint: SatPoint,
   pub(crate) timestamp: DateTime<Utc>,
-  pub(crate) metadata: Option<&'static str>,
 }
 
 impl PageContent for InscriptionHtml {
@@ -47,7 +46,6 @@ mod tests {
         sat: None,
         satpoint: satpoint(1, 0),
         timestamp: timestamp(0),
-        metadata: Some("Hello"),
       },
       "
         <h1>Inscription 1</h1>
@@ -85,8 +83,6 @@ mod tests {
           <dd><a class=monospace href=/output/1{64}:1>1{64}:1</a></dd>
           <dt>offset</dt>
           <dd>0</dd>
-          <dt>metadata</dt>
-          <dd>Hello</dd>
         </dl>
       "
       .unindent()
@@ -109,7 +105,6 @@ mod tests {
         sat: Some(Sat(1)),
         satpoint: satpoint(1, 0),
         timestamp: timestamp(0),
-        metadata: None,
       },
       "
         <h1>Inscription 1</h1>
@@ -142,7 +137,6 @@ mod tests {
         sat: None,
         satpoint: satpoint(1, 0),
         timestamp: timestamp(0),
-        metadata: None,
       },
       "
         <h1>Inscription 1</h1>

--- a/src/templates/inscription.rs
+++ b/src/templates/inscription.rs
@@ -14,6 +14,7 @@ pub(crate) struct InscriptionHtml {
   pub(crate) sat: Option<Sat>,
   pub(crate) satpoint: SatPoint,
   pub(crate) timestamp: DateTime<Utc>,
+  pub(crate) metadata: Option<&'static str>,
 }
 
 impl PageContent for InscriptionHtml {
@@ -46,6 +47,7 @@ mod tests {
         sat: None,
         satpoint: satpoint(1, 0),
         timestamp: timestamp(0),
+        metadata: Some("Hello"),
       },
       "
         <h1>Inscription 1</h1>
@@ -83,6 +85,8 @@ mod tests {
           <dd><a class=monospace href=/output/1{64}:1>1{64}:1</a></dd>
           <dt>offset</dt>
           <dd>0</dd>
+          <dt>metadata</dt>
+          <dd>Hello</dd>
         </dl>
       "
       .unindent()
@@ -105,6 +109,7 @@ mod tests {
         sat: Some(Sat(1)),
         satpoint: satpoint(1, 0),
         timestamp: timestamp(0),
+        metadata: None,
       },
       "
         <h1>Inscription 1</h1>
@@ -137,6 +142,7 @@ mod tests {
         sat: None,
         satpoint: satpoint(1, 0),
         timestamp: timestamp(0),
+        metadata: None,
       },
       "
         <h1>Inscription 1</h1>

--- a/templates/inscription.html
+++ b/templates/inscription.html
@@ -51,4 +51,8 @@
   <dd><a class=monospace href=/output/{{ self.satpoint.outpoint }}>{{ self.satpoint.outpoint }}</a></dd>
   <dt>offset</dt>
   <dd>{{ self.satpoint.offset }}</dd>
+%% if let Some(metadata) = self.metadata {
+  <dt>metadata</dt>
+  <dd>{{ metadata }}</dd>
+%% }
 </dl>

--- a/templates/inscription.html
+++ b/templates/inscription.html
@@ -51,7 +51,7 @@
   <dd><a class=monospace href=/output/{{ self.satpoint.outpoint }}>{{ self.satpoint.outpoint }}</a></dd>
   <dt>offset</dt>
   <dd>{{ self.satpoint.offset }}</dd>
-%% if let Some(metadata) = self.metadata {
+%% if let Some(metadata) = self.inscription.metadata() {
   <dt>metadata</dt>
   <dd>{{ metadata }}</dd>
 %% }


### PR DESCRIPTION
1. In casey ord github repo (https://github.com/casey/ord). There is a inscribe command situated at this path (https://github.com/casey/ord/blob/master/src/subcommand/wallet/inscribe.rs). We need add to start accepting a new parameter in this file.
Purpose of this param - this param will let anyone pass an additional string param and will attach this param to the meta information of the file. 

Example, 
ord wallet inscribe FILE --metadata "metada_string"


2. After the above, your inscription struct (https://github.com/casey/ord/blob/master/src/inscription.rs) will have the meta information that we attached to this. This struct powers this template (https://github.com/casey/ord/blob/master/src/templates/inscription.rs). So what we need to do is, start displaying meta information in this view. 
Currently this view looks like this (https://ordinals.com/inscription/431fea141cfc2e6f8dda9c209fbe9ce411e9e158d48661e86cbd0cc5e0bc33f5i0)
It should show meta information somwhere that we attached