### PR TITLE
Add "ord wallet cardinals" command to list the cardinal outputs.

### DIFF
--- a/src/subcommand/wallet.rs
+++ b/src/subcommand/wallet.rs
@@ -15,6 +15,7 @@ use {
 };
 
 pub mod balance;
+pub mod cardinals;
 pub mod create;
 pub(crate) mod inscribe;
 pub mod inscriptions;
@@ -48,6 +49,8 @@ pub(crate) enum Wallet {
   Transactions(transactions::Transactions),
   #[clap(about = "List wallet outputs")]
   Outputs,
+  #[clap(about = "List wallet cardinals")]
+  Cardinals,
 }
 
 impl Wallet {
@@ -63,6 +66,7 @@ impl Wallet {
       Self::Send(send) => send.run(options),
       Self::Transactions(transactions) => transactions.run(options),
       Self::Outputs => outputs::run(options),
+      Self::Cardinals => cardinals::run(options),
     }
   }
 }

--- a/src/subcommand/wallet.rs
+++ b/src/subcommand/wallet.rs
@@ -47,9 +47,9 @@ pub(crate) enum Wallet {
   Send(send::Send),
   #[clap(about = "See wallet transactions")]
   Transactions(transactions::Transactions),
-  #[clap(about = "List wallet outputs")]
+  #[clap(about = "List all unspent outputs in wallet")]
   Outputs,
-  #[clap(about = "List wallet cardinals")]
+  #[clap(about = "List unspent cardinal outputs in wallet")]
   Cardinals,
 }
 

--- a/src/subcommand/wallet/cardinals.rs
+++ b/src/subcommand/wallet/cardinals.rs
@@ -1,0 +1,33 @@
+use {super::*, crate::wallet::Wallet, std::collections::BTreeSet};
+
+#[derive(Serialize, Deserialize)]
+pub struct Cardinal {
+  pub output: OutPoint,
+  pub amount: u64,
+}
+
+pub(crate) fn run(options: Options) -> Result {
+  let index = Index::open(&options)?;
+  index.update()?;
+
+  let inscribed_utxos = index
+    .get_inscriptions(None)?
+    .keys()
+    .map(|satpoint| satpoint.outpoint)
+    .collect::<BTreeSet<OutPoint>>();
+
+  let mut outputs = Vec::new();
+  for (output, amount) in index.get_unspent_outputs(Wallet::load(&options)?)? {
+    if inscribed_utxos.contains(&output) {
+      continue;
+    }
+    outputs.push(Cardinal {
+      output,
+      amount: amount.to_sat(),
+    });
+  }
+
+  print_json(outputs)?;
+
+  Ok(())
+}

--- a/src/subcommand/wallet/cardinals.rs
+++ b/src/subcommand/wallet/cardinals.rs
@@ -20,13 +20,13 @@ pub(crate) fn run(options: Options) -> Result {
     .get_unspent_outputs(Wallet::load(&options)?)?
     .iter()
     .filter_map(|(output, amount)| {
-      if !inscribed_utxos.contains(&output) {
+      if inscribed_utxos.contains(output) {
+        None
+      } else {
         Some(Cardinal {
           output: *output,
           amount: amount.to_sat(),
         })
-      } else {
-        None
       }
     })
     .collect::<Vec<Cardinal>>();

--- a/src/subcommand/wallet/cardinals.rs
+++ b/src/subcommand/wallet/cardinals.rs
@@ -16,18 +16,22 @@ pub(crate) fn run(options: Options) -> Result {
     .map(|satpoint| satpoint.outpoint)
     .collect::<BTreeSet<OutPoint>>();
 
-  let mut outputs = Vec::new();
-  for (output, amount) in index.get_unspent_outputs(Wallet::load(&options)?)? {
-    if inscribed_utxos.contains(&output) {
-      continue;
-    }
-    outputs.push(Cardinal {
-      output,
-      amount: amount.to_sat(),
-    });
-  }
+  let cardinal_utxos = index
+    .get_unspent_outputs(Wallet::load(&options)?)?
+    .iter()
+    .filter_map(|(output, amount)| {
+      if !inscribed_utxos.contains(&output) {
+        Some(Cardinal {
+          output: *output,
+          amount: amount.to_sat(),
+        })
+      } else {
+        None
+      }
+    })
+    .collect::<Vec<Cardinal>>();
 
-  print_json(outputs)?;
+  print_json(cardinal_utxos)?;
 
   Ok(())
 }

--- a/tests/wallet.rs
+++ b/tests/wallet.rs
@@ -1,6 +1,7 @@
 use super::*;
 
 mod balance;
+mod cardinals;
 mod create;
 mod inscribe;
 mod inscriptions;

--- a/tests/wallet/cardinals.rs
+++ b/tests/wallet/cardinals.rs
@@ -1,0 +1,23 @@
+use {
+  super::*,
+  ord::subcommand::wallet::{cardinals::Cardinal, outputs::Output},
+};
+
+#[test]
+fn cardinals() {
+  let rpc_server = test_bitcoincore_rpc::spawn();
+  create_wallet(&rpc_server);
+
+  // this creates 2 more cardinal outpus and one inscribed output
+  inscribe(&rpc_server);
+
+  let cardinal_outputs = CommandBuilder::new("wallet cardinals")
+    .rpc_server(&rpc_server)
+    .output::<Vec<Cardinal>>();
+
+  let all_outputs = CommandBuilder::new("wallet outputs")
+    .rpc_server(&rpc_server)
+    .output::<Vec<Output>>();
+
+  assert_eq!(all_outputs.len() - cardinal_outputs.len(), 1);
+}

--- a/tests/wallet/cardinals.rs
+++ b/tests/wallet/cardinals.rs
@@ -14,7 +14,7 @@ fn cardinals() {
   let all_outputs = CommandBuilder::new("wallet outputs")
     .rpc_server(&rpc_server)
     .output::<Vec<Output>>();
-  
+
   let cardinal_outputs = CommandBuilder::new("wallet cardinals")
     .rpc_server(&rpc_server)
     .output::<Vec<Cardinal>>();

--- a/tests/wallet/cardinals.rs
+++ b/tests/wallet/cardinals.rs
@@ -8,16 +8,16 @@ fn cardinals() {
   let rpc_server = test_bitcoincore_rpc::spawn();
   create_wallet(&rpc_server);
 
-  // this creates 2 more cardinal outpus and one inscribed output
+  // this creates 2 more cardinal outputs and one inscribed output
   inscribe(&rpc_server);
-
-  let cardinal_outputs = CommandBuilder::new("wallet cardinals")
-    .rpc_server(&rpc_server)
-    .output::<Vec<Cardinal>>();
 
   let all_outputs = CommandBuilder::new("wallet outputs")
     .rpc_server(&rpc_server)
     .output::<Vec<Output>>();
+  
+  let cardinal_outputs = CommandBuilder::new("wallet cardinals")
+    .rpc_server(&rpc_server)
+    .output::<Vec<Cardinal>>();
 
   assert_eq!(all_outputs.len() - cardinal_outputs.len(), 1);
 }


### PR DESCRIPTION
There's no easy way to find a list of cardinal outputs. You have to list all the outputs and remove the inscriptions. 

Hence: `ord wallet cardinals`.