### PR TITLE
Identifying inscriptions

### DIFF
--- a/src/index/updater/inscription_updater.rs
+++ b/src/index/updater/inscription_updater.rs
@@ -106,7 +106,7 @@ impl<'a, 'db, 'tx> InscriptionUpdater<'a, 'db, 'tx> {
             index: id_index,
           };
 
-          id_index += 1; 
+          id_index += 1;
 
           floating_inscriptions.push(Flotsam {
             inscription_id,

--- a/src/index/updater/inscription_updater.rs
+++ b/src/index/updater/inscription_updater.rs
@@ -76,6 +76,7 @@ impl<'a, 'db, 'tx> InscriptionUpdater<'a, 'db, 'tx> {
     let mut floating_inscriptions = Vec::new();
     let mut inscribed_offsets = BTreeSet::new();
     let mut input_value = 0;
+    let mut id_index = 0;
     for tx_in in &tx.input {
       // skip subsidy since no inscriptions possible
       if tx_in.previous_output.is_null() {
@@ -102,8 +103,10 @@ impl<'a, 'db, 'tx> InscriptionUpdater<'a, 'db, 'tx> {
         if !inscribed_offsets.contains(&input_value) {
           let inscription_id = InscriptionId {
             txid,
-            index: 0, // will have to be updated for multi/batch inscriptions
+            index: id_index,
           };
+
+          id_index += 1; 
 
           floating_inscriptions.push(Flotsam {
             inscription_id,

--- a/src/index/updater/inscription_updater.rs
+++ b/src/index/updater/inscription_updater.rs
@@ -1,4 +1,4 @@
-use super::*;
+use {super::*, std::collections::BTreeSet};
 
 pub(super) struct Flotsam {
   inscription_id: InscriptionId,
@@ -73,50 +73,85 @@ impl<'a, 'db, 'tx> InscriptionUpdater<'a, 'db, 'tx> {
     txid: Txid,
     input_sat_ranges: Option<&VecDeque<(u64, u64)>>,
   ) -> Result<u64> {
-    let mut inscriptions = Vec::new();
-
+    let mut floating_inscriptions = Vec::new();
+    let mut inscribed_offsets = BTreeSet::new();
     let mut input_value = 0;
     for tx_in in &tx.input {
+      // skip subsidy since no inscriptions possible
       if tx_in.previous_output.is_null() {
         input_value += Height(self.height).subsidy();
-      } else {
-        for (old_satpoint, inscription_id) in
-          Index::inscriptions_on_output(self.satpoint_to_id, tx_in.previous_output)?
-        {
-          inscriptions.push(Flotsam {
-            offset: input_value + old_satpoint.offset,
+        continue;
+      }
+
+      // find existing inscriptions on input aka transfers of inscriptions
+      for (old_satpoint, inscription_id) in
+        Index::inscriptions_on_output(self.satpoint_to_id, tx_in.previous_output)?
+      {
+        floating_inscriptions.push(Flotsam {
+          offset: input_value + old_satpoint.offset,
+          inscription_id,
+          origin: Origin::Old(old_satpoint),
+        });
+
+        inscribed_offsets.insert(input_value + old_satpoint.offset);
+      }
+
+      // find new inscriptions
+      if let Some(_inscription) = Inscription::from_tx_input(tx_in) {
+        // ignore new inscriptions on already inscribed offset (sats)
+        if !inscribed_offsets.contains(&input_value) {
+          let inscription_id = InscriptionId {
+            txid,
+            index: 0, // will have to be updated for multi/batch inscriptions
+          };
+
+          floating_inscriptions.push(Flotsam {
             inscription_id,
-            origin: Origin::Old(old_satpoint),
+            offset: input_value,
+            origin: Origin::New(0), // 0 is placeholder, calculate fee later
           });
         }
+      }
 
-        input_value += if let Some(value) = self.value_cache.remove(&tx_in.previous_output) {
-          value
-        } else if let Some(value) = self
-          .outpoint_to_value
-          .remove(&tx_in.previous_output.store())?
-        {
-          value.value()
-        } else {
-          self.value_receiver.blocking_recv().ok_or_else(|| {
-            anyhow!(
-              "failed to get transaction for {}",
-              tx_in.previous_output.txid
-            )
-          })?
-        }
+      // different ways to get the utxo set (input amount)
+      input_value += if let Some(value) = self.value_cache.remove(&tx_in.previous_output) {
+        value
+      } else if let Some(value) = self
+        .outpoint_to_value
+        .remove(&tx_in.previous_output.store())?
+      {
+        value.value()
+      } else {
+        self.value_receiver.blocking_recv().ok_or_else(|| {
+          anyhow!(
+            "failed to get transaction for {}",
+            tx_in.previous_output.txid
+          )
+        })?
       }
     }
 
-    if inscriptions.iter().all(|flotsam| flotsam.offset != 0)
-      && Inscription::from_transaction(tx).is_some()
-    {
-      inscriptions.push(Flotsam {
-        inscription_id: txid.into(),
-        offset: 0,
-        origin: Origin::New(input_value - tx.output.iter().map(|txout| txout.value).sum::<u64>()),
-      });
-    };
+    // calulate genesis fee for new inscriptions
+    let total_output_value = tx.output.iter().map(|txout| txout.value).sum::<u64>();
+    let mut floating_inscriptions = floating_inscriptions
+      .into_iter()
+      .map(|flotsam| {
+        if let Flotsam {
+          inscription_id,
+          offset,
+          origin: Origin::New(_),
+        } = flotsam
+        {
+          Flotsam {
+            inscription_id,
+            offset,
+            origin: Origin::New(input_value - total_output_value),
+          }
+        } else {
+          flotsam
+        }
+      })
+      .collect::<Vec<Flotsam>>();
 
     let is_coinbase = tx
       .input
@@ -125,21 +160,19 @@ impl<'a, 'db, 'tx> InscriptionUpdater<'a, 'db, 'tx> {
       .unwrap_or_default();
 
     if is_coinbase {
-      inscriptions.append(&mut self.flotsam);
+      floating_inscriptions.append(&mut self.flotsam);
     }
 
-    inscriptions.sort_by_key(|flotsam| flotsam.offset);
-    let mut inscriptions = inscriptions.into_iter().peekable();
+    floating_inscriptions.sort_by_key(|flotsam| flotsam.offset);
+    let mut inscriptions = floating_inscriptions.into_iter().peekable();
 
     let mut output_value = 0;
     for (vout, tx_out) in tx.output.iter().enumerate() {
       let end = output_value + tx_out.value;
-
       while let Some(flotsam) = inscriptions.peek() {
         if flotsam.offset >= end {
           break;
         }
-
         let new_satpoint = SatPoint {
           outpoint: OutPoint {
             txid,
@@ -150,11 +183,10 @@ impl<'a, 'db, 'tx> InscriptionUpdater<'a, 'db, 'tx> {
 
         self.update_inscription_location(
           input_sat_ranges,
-          inscriptions.next().unwrap(),
+          inscriptions.next().unwrap(), // This will need to change when we implement multiple inscriptions per TX (#1298).
           new_satpoint,
         )?;
       }
-
       output_value = end;
 
       self.value_cache.insert(


### PR DESCRIPTION
At the moment `ord` only parses new inscriptions that are in the first input of a transaction. This PR rectifies this mistake by also parsing inscriptions on other transaction inputs. This will make future improvements like batch inscriptions and parent-child relationships easier. Out of this follows that there can now be `inscription_id`s that end with `...i1`,`...i54`/, etc. (not only `...i0`). The number at the end is just the index of the inscription in the transaction. Another question is which sat an inscription is inscribed on. At the moment it is the first sat of the first output but this is implicit. If there is multiple inscription inputs but only one output, which sat is the second inscription inscribed on? Does there have to be a seperate output for the inscription to be valid or is it just discarded if a corresponding output is missing? Through an optional (uneven) tag we could build pointers to the sat the inscription is supposed to be on. It could specify the sat offset in the transaction as the sat this inscription is inscribed on. Here with offset=1000:
```
OP_FALSE
OP_IF
  OP_PUSH "ord"
  OP_3
  OP_PUSH 1000
  OP_1
  OP_PUSH "text/plain;charset=utf-8"
  OP_0
  OP_PUSH "first inscription"
OP_ENDIF
```

Thinking even further a more general consensus question arises as well. Should it be possible to have more than one inscription *per input*? Practically, this would be achieved by putting multiple of our envelope constructions in the input's witness, like so:
```
OP_FALSE
OP_IF
  OP_PUSH "ord"
  OP_1
  OP_PUSH "text/plain;charset=utf-8"
  OP_0
  OP_PUSH "first inscription"
OP_ENDIF
OP_FALSE
OP_IF
  OP_PUSH "ord"
  OP_1
  OP_PUSH "text/plain;charset=utf-8"
  OP_0
  OP_PUSH "second inscription"
OP_ENDIF
```
Having multiple inscriptions per input would make batch inscriptions way more space efficient since an inscription wouldn't need an extra input.

#2000 
#1769 