### PR TITLE
Handle interrupts better

### DIFF
--- a/src/index/updater.rs
+++ b/src/index/updater.rs
@@ -159,7 +159,7 @@ impl Updater {
           )?;
       }
 
-      if INTERRUPTS.load(atomic::Ordering::Relaxed) > 0 {
+      if SHUTTING_DOWN.load(atomic::Ordering::Relaxed) {
         break;
       }
     }
@@ -339,7 +339,7 @@ impl Updater {
     // If value_receiver still has values something went wrong with the last block
     // Could be an assert, shouldn't recover from this and commit the last block
     let Err(TryRecvError::Empty) = value_receiver.try_recv() else {
-      return Err(anyhow!("Previous block did not consume all input values")); 
+      return Err(anyhow!("Previous block did not consume all input values"));
     };
 
     let mut outpoint_to_value = wtx.open_table(OUTPOINT_TO_VALUE)?;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -61,15 +61,16 @@ use {
     path::{Path, PathBuf},
     process::{self, Command},
     str::FromStr,
-    sync::{atomic, Arc, Mutex},
+    sync::{
+      atomic::{self, AtomicBool},
+      Arc, Mutex,
+    },
     thread,
     time::{Duration, Instant, SystemTime},
   },
   tempfile::TempDir,
   tokio::{runtime::Runtime, task},
 };
-
-use std::sync::atomic::AtomicBool;
 
 pub use crate::{
   fee_rate::FeeRate, object::Object, rarity::Rarity, sat::Sat, sat_point::SatPoint,


### PR DESCRIPTION
This PR changes the amount of times the user has to hit Ctrl+C in order to kill the process from 7 to 2, this makes it easier for the user to immediately shutdown the process.