### PR TITLE
Switch to clippy nightly

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -49,17 +49,25 @@ jobs:
     steps:
     - uses: actions/checkout@v2
 
-    - name: Install Rust Toolchain Components
+    - name: Install rustfmt
       uses: actions-rs/toolchain@v1
       with:
-        components: clippy, rustfmt
+        components: rustfmt
         override: true
         toolchain: stable
 
+    - name: Install clippy nightly
+      uses: actions-rs/toolchain@v1
+      with:
+        components: clippy
+        toolchain: nightly
+
     - uses: Swatinem/rust-cache@v2
+      with:
+        key: "clippy-nightly"
 
     - name: Clippy
-      run: cargo clippy --all --all-targets
+      run: cargo +nightly clippy --all --all-targets
 
     - name: Format
       run: cargo fmt --all -- --check

--- a/justfile
+++ b/justfile
@@ -15,10 +15,10 @@ fmt:
   cargo fmt
 
 clippy:
-  cargo clippy --all --all-targets -- -D warnings
+  cargo +nightly clippy --all --all-targets -- -D warnings
 
 lclippy:
-  cargo lclippy --all --all-targets -- -D warnings
+  cargo +nightly lclippy --all --all-targets -- -D warnings
 
 deploy branch chain domain:
   ssh root@{{domain}} "mkdir -p deploy \


### PR DESCRIPTION
This PR switches `clippy` to `nightly`, both in ci scripts and for `just clippy` and friends. This is to workaround [this issue](https://github.com/clap-rs/clap/issues/4733), which I believe is fixed [here](https://github.com/rust-lang/rust-clippy/pull/10502), but hasn't landed in the stable version of `clippy`. This PR should be reverted once the fix lands.

Fixes #2035.

Of course this has some downsides:
- Nightly `clippy` is not stable, so we may have some CI issues introduced in newer nightly versions. (We could try to pin down `clippy` to an exact nightly version, which would avoid this. Any opinions?)
- CI caches get bigger.
- Before locally running `just clippy` (or e.g. `just ci`) you have to run `rustup install nightly`.
